### PR TITLE
docs: migrate controller component documentation and examples

### DIFF
--- a/docs-nextra/README.md
+++ b/docs-nextra/README.md
@@ -1,6 +1,6 @@
 # Echo UI Nextra documentation
 
-This workspace runs beside the IslandJS documentation while content is migrated incrementally. It currently owns the bilingual landing, introduction, installation, declaration, and about experience. From the repository root:
+This workspace runs beside the IslandJS documentation while content is migrated incrementally. It currently owns the bilingual landing, guides, and controller documentation. From the repository root:
 
 ```bash
 pnpm dev:docs:nextra
@@ -11,7 +11,7 @@ pnpm build:docs:nextra
 
 English pages live under `/en/`, and their Chinese counterparts use the same path below `/zh/`. Keeping the route structures aligned lets Nextra's locale switch preserve the current page.
 
-After a build, verify representative routes, localized navigation, page metadata, edit links, and internal assets with:
+After a build, verify routes, localized navigation, page metadata, edit links, internal assets, and hydrated controller demos with:
 
 ```bash
 pnpm test:docs:nextra

--- a/docs-nextra/app/_components/controller-api.tsx
+++ b/docs-nextra/app/_components/controller-api.tsx
@@ -1,0 +1,1054 @@
+import type { FC } from 'react'
+import styles from './controller-docs.module.css'
+
+export type ControllerName =
+  'button' | 'checkbox' | 'envelope' | 'input' | 'knob' | 'radio' | 'slider' | 'switch'
+
+type Locale = 'en' | 'zh'
+type LocalizedText = Readonly<Record<Locale, string>>
+
+type ApiRow = Readonly<{
+  name: string
+  type: string
+  defaultValue: string
+  description: LocalizedText
+  required?: boolean
+}>
+
+type ApiSection = Readonly<{
+  name: string
+  inherited: LocalizedText
+  rows: readonly ApiRow[]
+}>
+
+type ControllerApiDefinition = Readonly<{
+  main: ApiSection
+  group?: ApiSection
+}>
+
+const text = (en: string, zh: string): LocalizedText => ({ en, zh })
+
+const definitions: Record<ControllerName, ControllerApiDefinition> = {
+  button: {
+    main: {
+      name: 'Button',
+      inherited: text(
+        'Also accepts React.HTMLAttributes<HTMLButtonElement>. Native button children and click handlers are forwarded.',
+        '同时接受 React.HTMLAttributes<HTMLButtonElement>；原生按钮的子内容与点击处理函数会继续传递。',
+      ),
+      rows: [
+        {
+          name: 'value',
+          type: 'unknown',
+          defaultValue: '—',
+          description: text(
+            'Option value used only when the button is inside Button.Group.',
+            '仅在按钮位于 Button.Group 内时使用的选项值。',
+          ),
+        },
+        {
+          name: 'disabled',
+          type: 'boolean',
+          defaultValue: 'false',
+          description: text('Disables the native button.', '禁用原生按钮。'),
+        },
+        {
+          name: 'size',
+          type: "'sm' | 'md' | 'lg'",
+          defaultValue: "'md'",
+          description: text('Controls button padding and type size.', '控制按钮内边距和字号。'),
+        },
+        {
+          name: 'radius',
+          type: "'none' | 'sm' | 'md' | 'lg' | 'full'",
+          defaultValue: "'md'",
+          description: text('Sets the button corner radius.', '设置按钮圆角。'),
+        },
+        {
+          name: 'toggled',
+          type: 'boolean',
+          defaultValue: 'false',
+          description: text(
+            'Controls the visual pressed state; a standalone Button does not toggle itself.',
+            '控制视觉按下状态；独立 Button 不会自行切换该状态。',
+          ),
+        },
+        {
+          name: 'onToggleChange',
+          type: '(toggled: boolean) => void',
+          defaultValue: '—',
+          description: text(
+            'Runs after mount and whenever the effective toggled state changes.',
+            '挂载后以及有效 toggled 状态变化时调用。',
+          ),
+        },
+      ],
+    },
+    group: {
+      name: 'Button.Group',
+      inherited: text(
+        'Also accepts React.HTMLAttributes<HTMLDivElement>. Group selection is controlled: update value from onChange.',
+        '同时接受 React.HTMLAttributes<HTMLDivElement>。分组选择为受控模式：请在 onChange 中更新 value。',
+      ),
+      rows: [
+        {
+          name: 'value',
+          type: 'unknown | unknown[]',
+          defaultValue: '[]',
+          description: text(
+            'Selected value for single-select, or selected values for multi-select.',
+            '单选时为一个选中值，多选时为选中值数组。',
+          ),
+        },
+        {
+          name: 'disabled',
+          type: 'boolean',
+          defaultValue: 'false',
+          description: text('Disables every grouped button.', '禁用组内所有按钮。'),
+        },
+        {
+          name: 'size',
+          type: "'sm' | 'md' | 'lg'",
+          defaultValue: "'md'",
+          description: text('Default size inherited by children.', '子按钮继承的默认尺寸。'),
+        },
+        {
+          name: 'radius',
+          type: "'none' | 'sm' | 'md' | 'lg' | 'full'",
+          defaultValue: "'md'",
+          description: text('Outer radius inherited by children.', '子按钮继承的外侧圆角。'),
+        },
+        {
+          name: 'classNames',
+          type: '{ button?: string }',
+          defaultValue: '—',
+          description: text('Class applied to every child button.', '应用到每个子按钮的类名。'),
+        },
+        {
+          name: 'styles',
+          type: '{ button?: React.CSSProperties }',
+          defaultValue: '—',
+          description: text(
+            'Inline style applied to every child button.',
+            '应用到每个子按钮的行内样式。',
+          ),
+        },
+        {
+          name: 'onChange',
+          type: '(values: unknown | unknown[]) => void',
+          defaultValue: '—',
+          description: text('Reports the next controlled selection.', '返回下一次受控选择值。'),
+        },
+      ],
+    },
+  },
+  checkbox: {
+    main: {
+      name: 'Checkbox',
+      inherited: text(
+        'Accepts React.HTMLAttributes<HTMLInputElement>. Echo UI renders a native input[type="checkbox"] inside a label, but input-specific props such as name are not part of the public type.',
+        '接受 React.HTMLAttributes<HTMLInputElement>。Echo UI 会在 label 内渲染原生 input[type="checkbox"]，但 name 等输入框专属属性不在公开类型中。',
+      ),
+      rows: [
+        {
+          name: 'value',
+          type: 'unknown',
+          defaultValue: '—',
+          description: text(
+            'Option value reported inside Checkbox.Group.',
+            '在 Checkbox.Group 中回传的选项值。',
+          ),
+        },
+        {
+          name: 'checked',
+          type: 'boolean',
+          defaultValue: 'false',
+          description: text(
+            'Initial and externally synchronized checked state.',
+            '初始选中状态，并可由外部同步更新。',
+          ),
+        },
+        {
+          name: 'disabled',
+          type: 'boolean',
+          defaultValue: 'false',
+          description: text('Disables the native checkbox.', '禁用原生复选框。'),
+        },
+        {
+          name: 'size',
+          type: "'sm' | 'md' | 'lg'",
+          defaultValue: "'md'",
+          description: text('Sets control and label size.', '设置控件和标签尺寸。'),
+        },
+        {
+          name: 'color',
+          type: 'string',
+          defaultValue: 'var(--echo-primary)',
+          description: text('Color of the checked indicator.', '选中指示块的颜色。'),
+        },
+        {
+          name: 'classNames',
+          type: '{ label?: string }',
+          defaultValue: '—',
+          description: text('Class for the visible label.', '可见标签的类名。'),
+        },
+        {
+          name: 'styles',
+          type: '{ label?: React.CSSProperties }',
+          defaultValue: '—',
+          description: text('Inline style for the visible label.', '可见标签的行内样式。'),
+        },
+        {
+          name: 'onChange',
+          type: '(event: CheckboxChangeEvent) => void',
+          defaultValue: '—',
+          description: text(
+            'Reports { value, nativeEvent }; standalone value is the next boolean.',
+            '返回 { value, nativeEvent }；独立使用时 value 是下一布尔值。',
+          ),
+        },
+      ],
+    },
+    group: {
+      name: 'Checkbox.Group',
+      inherited: text(
+        'Also accepts React.HTMLAttributes<HTMLDivElement>. Keep value in state to use the group as one controlled field.',
+        '同时接受 React.HTMLAttributes<HTMLDivElement>。请把 value 保存在状态中，将分组作为一个受控字段使用。',
+      ),
+      rows: [
+        {
+          name: 'value',
+          type: 'unknown[]',
+          defaultValue: '[]',
+          description: text('Currently selected child values.', '当前选中的子项值。'),
+        },
+        {
+          name: 'disabled',
+          type: 'boolean',
+          defaultValue: 'false',
+          description: text('Disables every checkbox.', '禁用组内所有复选框。'),
+        },
+        {
+          name: 'checked',
+          type: 'boolean',
+          defaultValue: '—',
+          description: text(
+            'Present in the public group type but not propagated to children; prefer value.',
+            '存在于公开分组类型中，但不会传给子项；应优先使用 value。',
+          ),
+        },
+        {
+          name: 'size',
+          type: "'sm' | 'md' | 'lg'",
+          defaultValue: "'md'",
+          description: text('Default child size.', '子项默认尺寸。'),
+        },
+        {
+          name: 'color',
+          type: 'string',
+          defaultValue: 'var(--echo-primary)',
+          description: text('Default checked color.', '默认选中颜色。'),
+        },
+        {
+          name: 'classNames',
+          type: '{ checkbox?: string; label?: string }',
+          defaultValue: '—',
+          description: text(
+            'Classes shared by child controls and labels.',
+            '子控件和标签共享的类名。',
+          ),
+        },
+        {
+          name: 'styles',
+          type: '{ checkbox?: CSSProperties; label?: CSSProperties }',
+          defaultValue: '—',
+          description: text(
+            'Inline styles shared by child controls and labels.',
+            '子控件和标签共享的行内样式。',
+          ),
+        },
+        {
+          name: 'onChange',
+          type: '(event: CheckboxChangeEvent) => void',
+          defaultValue: '—',
+          description: text(
+            'Reports the next value array and native event.',
+            '返回下一值数组和原生事件。',
+          ),
+        },
+      ],
+    },
+  },
+  envelope: {
+    main: {
+      name: 'Envelope',
+      inherited: text(
+        'Also accepts React.HTMLAttributes<HTMLDivElement>. The visualization uses pointer-driven SVG nodes; provide equivalent form inputs when keyboard access is required.',
+        '同时接受 React.HTMLAttributes<HTMLDivElement>。可视化使用指针拖动 SVG 节点；需要键盘访问时，请提供等价表单输入。',
+      ),
+      rows: [
+        {
+          name: 'data',
+          type: 'EnvelopeData',
+          defaultValue: '—',
+          required: true,
+          description: text(
+            'ADSR, AHDSR, or DADSR values to display and edit.',
+            '要显示和编辑的 ADSR、AHDSR 或 DADSR 数值。',
+          ),
+        },
+        {
+          name: 'limits',
+          type: 'EnvelopeLimits',
+          defaultValue: '{ delay: 1, attack: 1, hold: 1, decay: 1, release: 1 }',
+          description: text(
+            'Maximum duration for each time stage. Omitted delay or hold stages receive a zero limit.',
+            '各时间阶段的最大时长；省略 delay 或 hold 时，对应上限为 0。',
+          ),
+        },
+        {
+          name: 'lineColor',
+          type: 'string',
+          defaultValue: 'var(--echo-primary)',
+          description: text('Envelope line color.', '包络线颜色。'),
+        },
+        {
+          name: 'lineWidth',
+          type: 'number',
+          defaultValue: '3',
+          description: text('Envelope line width in SVG units.', '包络线宽度（SVG 单位）。'),
+        },
+        {
+          name: 'nodeColor',
+          type: 'string',
+          defaultValue: 'var(--echo-secondary)',
+          description: text('Drag-node outline color.', '拖动节点轮廓颜色。'),
+        },
+        {
+          name: 'nodeSize',
+          type: 'number',
+          defaultValue: '6',
+          description: text('Drag-node radius in SVG units.', '拖动节点半径（SVG 单位）。'),
+        },
+        {
+          name: 'onChange',
+          type: '(data: EnvelopeData) => void',
+          defaultValue: '—',
+          description: text('Reports values during dragging.', '拖动过程中持续返回数值。'),
+        },
+        {
+          name: 'onChangeEnd',
+          type: '(data: EnvelopeData) => void',
+          defaultValue: '—',
+          description: text('Reports final values when dragging ends.', '拖动结束时返回最终数值。'),
+        },
+      ],
+    },
+  },
+  input: {
+    main: {
+      name: 'Input',
+      inherited: text(
+        'Accepts React.InputHTMLAttributes<HTMLInputElement> except children, size, and the native onChange signature.',
+        '接受 React.InputHTMLAttributes<HTMLInputElement>，但 children、size 与原生 onChange 签名除外。',
+      ),
+      rows: [
+        {
+          name: 'value',
+          type: 'string | number',
+          defaultValue: '0',
+          description: text(
+            'Initial and externally synchronized value.',
+            '初始值，并可由外部同步更新。',
+          ),
+        },
+        {
+          name: 'type',
+          type: "'text' | 'number'",
+          defaultValue: "'number'",
+          description: text(
+            'Selects text entry or numeric entry with drag editing.',
+            '选择文本输入，或支持拖动编辑的数字输入。',
+          ),
+        },
+        {
+          name: 'size',
+          type: "'sm' | 'md' | 'lg'",
+          defaultValue: "'md'",
+          description: text('Input size.', '输入框尺寸。'),
+        },
+        {
+          name: 'radius',
+          type: "'none' | 'sm' | 'md' | 'lg' | 'full'",
+          defaultValue: "'md'",
+          description: text('Input corner radius.', '输入框圆角。'),
+        },
+        {
+          name: 'bilateral',
+          type: 'boolean',
+          defaultValue: 'false',
+          description: text(
+            'Draws progress outward from the range midpoint.',
+            '让进度从数值范围中点向外绘制。',
+          ),
+        },
+        {
+          name: 'min',
+          type: 'number',
+          defaultValue: '0',
+          description: text('Minimum numeric value.', '数字最小值。'),
+        },
+        {
+          name: 'max',
+          type: 'number',
+          defaultValue: '100',
+          description: text('Maximum numeric value.', '数字最大值。'),
+        },
+        {
+          name: 'step',
+          type: 'number',
+          defaultValue: '1',
+          description: text('Increment used while dragging.', '拖动时使用的步进值。'),
+        },
+        {
+          name: 'sensitivity',
+          type: '1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10',
+          defaultValue: '5',
+          description: text('Vertical drag sensitivity.', '垂直拖动灵敏度。'),
+        },
+        {
+          name: 'prohibitDrag',
+          type: 'boolean',
+          defaultValue: 'false',
+          description: text('Disables pointer drag editing.', '禁用指针拖动编辑。'),
+        },
+        {
+          name: 'hideProgress',
+          type: 'boolean',
+          defaultValue: 'false',
+          description: text('Hides the numeric progress fill.', '隐藏数字进度填充。'),
+        },
+        {
+          name: 'progressColor',
+          type: 'string',
+          defaultValue: 'var(--echo-primary)',
+          description: text('Numeric progress fill color.', '数字进度填充颜色。'),
+        },
+        {
+          name: 'onChange',
+          type: '(event: InputChangeEvent) => void',
+          defaultValue: '—',
+          description: text(
+            'Reports { value, nativeEvent? } for typing and dragging.',
+            '输入或拖动时返回 { value, nativeEvent? }。',
+          ),
+        },
+      ],
+    },
+  },
+  knob: {
+    main: {
+      name: 'Knob',
+      inherited: text(
+        'Also accepts React.HTMLAttributes<HTMLDivElement>. The current control is pointer-driven; mirror it with a keyboard-operable input for accessible forms.',
+        '同时接受 React.HTMLAttributes<HTMLDivElement>。当前控件由指针驱动；无障碍表单应同时提供可键盘操作的输入。',
+      ),
+      rows: [
+        {
+          name: 'value',
+          type: 'number',
+          defaultValue: '0',
+          description: text(
+            'Initial and externally synchronized value.',
+            '初始值，并可由外部同步更新。',
+          ),
+        },
+        {
+          name: 'min',
+          type: 'number',
+          defaultValue: '-10',
+          description: text('Minimum value.', '最小值。'),
+        },
+        {
+          name: 'max',
+          type: 'number',
+          defaultValue: '10',
+          description: text('Maximum value.', '最大值。'),
+        },
+        {
+          name: 'step',
+          type: 'number',
+          defaultValue: '1',
+          description: text('Drag increment.', '拖动步进值。'),
+        },
+        {
+          name: 'disabled',
+          type: 'boolean',
+          defaultValue: 'false',
+          description: text('Disables pointer interaction.', '禁用指针交互。'),
+        },
+        {
+          name: 'rotationRange',
+          type: 'number',
+          defaultValue: '270',
+          description: text(
+            'Available rotation in degrees, clamped from 90 to 360.',
+            '可用旋转角度，限制在 90 到 360 度。',
+          ),
+        },
+        {
+          name: 'bilateral',
+          type: 'boolean',
+          defaultValue: 'false',
+          description: text('Draws progress from the range midpoint.', '从数值范围中点绘制进度。'),
+        },
+        {
+          name: 'sensitivity',
+          type: '1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10',
+          defaultValue: '1',
+          description: text('Vertical drag sensitivity.', '垂直拖动灵敏度。'),
+        },
+        {
+          name: 'size',
+          type: 'number | string',
+          defaultValue: "'4rem'",
+          description: text('Knob width and height.', '旋钮宽度和高度。'),
+        },
+        {
+          name: 'buttonColor',
+          type: 'string',
+          defaultValue: 'var(--echo-button)',
+          description: text('Center button color.', '中心按钮颜色。'),
+        },
+        {
+          name: 'trackColor',
+          type: 'string',
+          defaultValue: 'var(--echo-input)',
+          description: text('Track color.', '轨道颜色。'),
+        },
+        {
+          name: 'trackWidth',
+          type: 'number | string',
+          defaultValue: "'0.5rem'",
+          description: text('Track thickness.', '轨道厚度。'),
+        },
+        {
+          name: 'progressColor',
+          type: 'string',
+          defaultValue: 'var(--echo-primary)',
+          description: text('Progress arc color.', '进度弧颜色。'),
+        },
+        {
+          name: 'pointerWidth',
+          type: 'number | string',
+          defaultValue: "'0.375rem'",
+          description: text('Pointer width.', '指针宽度。'),
+        },
+        {
+          name: 'pointerHeight',
+          type: 'number | string',
+          defaultValue: "'1rem'",
+          description: text('Pointer height.', '指针高度。'),
+        },
+        {
+          name: 'pointerColor',
+          type: 'string',
+          defaultValue: 'var(--echo-primary)',
+          description: text('Pointer color.', '指针颜色。'),
+        },
+        {
+          name: 'topLabel',
+          type: 'string | ReactNode',
+          defaultValue: '—',
+          description: text('Content above the knob.', '旋钮上方内容。'),
+        },
+        {
+          name: 'bottomLabel',
+          type: 'string | ReactNode',
+          defaultValue: '—',
+          description: text('Content below the knob.', '旋钮下方内容。'),
+        },
+        {
+          name: 'classNames',
+          type: '{ button?: string; topLabel?: string; bottomLabel?: string }',
+          defaultValue: '—',
+          description: text('Classes for named knob slots.', '各旋钮插槽的类名。'),
+        },
+        {
+          name: 'styles',
+          type: '{ button?: CSSProperties; topLabel?: CSSProperties; bottomLabel?: CSSProperties }',
+          defaultValue: '—',
+          description: text('Inline styles for named knob slots.', '各旋钮插槽的行内样式。'),
+        },
+        {
+          name: 'onChange',
+          type: '(value: number) => void',
+          defaultValue: '—',
+          description: text('Reports values while dragging.', '拖动时持续返回数值。'),
+        },
+        {
+          name: 'onChangeEnd',
+          type: '(value: number) => void',
+          defaultValue: '—',
+          description: text('Reports the final drag value.', '返回拖动结束时的最终值。'),
+        },
+      ],
+    },
+    group: {
+      name: 'Knob.Group',
+      inherited: text(
+        'Also accepts React.HTMLAttributes<HTMLDivElement>. It shares presentation and range props; each Knob keeps its own value and callbacks.',
+        '同时接受 React.HTMLAttributes<HTMLDivElement>。它共享外观与范围属性；每个 Knob 保留自己的 value 和回调。',
+      ),
+      rows: [
+        {
+          name: 'min, max, step',
+          type: 'number',
+          defaultValue: '-10, 10, 1',
+          description: text('Shared range and increment.', '共享的范围和步进值。'),
+        },
+        {
+          name: 'disabled',
+          type: 'boolean',
+          defaultValue: 'false',
+          description: text('Disables all child knobs.', '禁用所有子旋钮。'),
+        },
+        {
+          name: 'rotationRange',
+          type: 'number',
+          defaultValue: '270',
+          description: text('Shared rotation range.', '共享旋转范围。'),
+        },
+        {
+          name: 'bilateral',
+          type: 'boolean',
+          defaultValue: 'false',
+          description: text('Shared bilateral mode.', '共享双向模式。'),
+        },
+        {
+          name: 'sensitivity',
+          type: '1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10',
+          defaultValue: '1',
+          description: text('Shared drag sensitivity.', '共享拖动灵敏度。'),
+        },
+        {
+          name: 'size',
+          type: 'number | string',
+          defaultValue: "'4rem'",
+          description: text('Shared knob size.', '共享旋钮尺寸。'),
+        },
+        {
+          name: 'buttonColor, trackColor, progressColor, pointerColor',
+          type: 'string',
+          defaultValue: 'Echo theme tokens',
+          description: text('Shared control colors.', '共享控件颜色。'),
+        },
+        {
+          name: 'trackWidth, pointerWidth, pointerHeight',
+          type: 'number | string',
+          defaultValue: "'0.5rem', '0.375rem', '1rem'",
+          description: text('Shared track and pointer dimensions.', '共享轨道和指针尺寸。'),
+        },
+        {
+          name: 'classNames',
+          type: '{ knob?: string; button?: string; topLabel?: string; bottomLabel?: string }',
+          defaultValue: '—',
+          description: text(
+            'Classes applied across child knob slots.',
+            '应用到各子旋钮插槽的类名。',
+          ),
+        },
+        {
+          name: 'styles',
+          type: '{ knob?: CSSProperties; button?: CSSProperties; topLabel?: CSSProperties; bottomLabel?: CSSProperties }',
+          defaultValue: '—',
+          description: text(
+            'Inline styles applied across child knob slots.',
+            '应用到各子旋钮插槽的行内样式。',
+          ),
+        },
+      ],
+    },
+  },
+  radio: {
+    main: {
+      name: 'Radio',
+      inherited: text(
+        'Accepts React.HTMLAttributes<HTMLInputElement>. Echo UI renders a native input[type="radio"] inside a label, but input-specific props such as name are not part of the public type.',
+        '接受 React.HTMLAttributes<HTMLInputElement>。Echo UI 会在 label 内渲染原生 input[type="radio"]，但 name 等输入框专属属性不在公开类型中。',
+      ),
+      rows: [
+        {
+          name: 'value',
+          type: 'unknown',
+          defaultValue: '—',
+          description: text(
+            'Option value reported by Radio.Group.',
+            '由 Radio.Group 回传的选项值。',
+          ),
+        },
+        {
+          name: 'checked',
+          type: 'boolean',
+          defaultValue: 'false',
+          description: text('Standalone checked state.', '独立使用时的选中状态。'),
+        },
+        {
+          name: 'disabled',
+          type: 'boolean',
+          defaultValue: 'false',
+          description: text('Disables the native radio.', '禁用原生单选框。'),
+        },
+        {
+          name: 'size',
+          type: "'sm' | 'md' | 'lg'",
+          defaultValue: "'md'",
+          description: text('Sets control and label size.', '设置控件和标签尺寸。'),
+        },
+        {
+          name: 'color',
+          type: 'string',
+          defaultValue: 'var(--echo-primary)',
+          description: text('Selected indicator color.', '选中指示点颜色。'),
+        },
+        {
+          name: 'classNames',
+          type: '{ label?: string }',
+          defaultValue: '—',
+          description: text('Class for the visible label.', '可见标签的类名。'),
+        },
+        {
+          name: 'styles',
+          type: '{ label?: React.CSSProperties }',
+          defaultValue: '—',
+          description: text('Inline style for the visible label.', '可见标签的行内样式。'),
+        },
+        {
+          name: 'onChange',
+          type: '(event: RadioChangeEvent) => void',
+          defaultValue: '—',
+          description: text('Reports the option value and native event.', '返回选项值和原生事件。'),
+        },
+      ],
+    },
+    group: {
+      name: 'Radio.Group',
+      inherited: text(
+        'Also accepts React.HTMLAttributes<HTMLDivElement>. Selection is controlled. Radio.Group does not add radiogroup semantics or a shared native name automatically.',
+        '同时接受 React.HTMLAttributes<HTMLDivElement>。选择为受控模式。Radio.Group 不会自动添加 radiogroup 语义或共享的原生 name。',
+      ),
+      rows: [
+        {
+          name: 'value',
+          type: 'unknown',
+          defaultValue: '—',
+          description: text('Currently selected child value.', '当前选中的子项值。'),
+        },
+        {
+          name: 'disabled',
+          type: 'boolean',
+          defaultValue: 'false',
+          description: text('Disables every radio.', '禁用组内所有单选框。'),
+        },
+        {
+          name: 'size',
+          type: "'sm' | 'md' | 'lg'",
+          defaultValue: "'md'",
+          description: text('Default child size.', '子项默认尺寸。'),
+        },
+        {
+          name: 'color',
+          type: 'string',
+          defaultValue: 'var(--echo-primary)',
+          description: text('Default selected color.', '默认选中颜色。'),
+        },
+        {
+          name: 'classNames',
+          type: '{ radio?: string; label?: string }',
+          defaultValue: '—',
+          description: text(
+            'Classes shared by child controls and labels.',
+            '子控件和标签共享的类名。',
+          ),
+        },
+        {
+          name: 'styles',
+          type: '{ radio?: CSSProperties; label?: CSSProperties }',
+          defaultValue: '—',
+          description: text(
+            'Inline styles shared by child controls and labels.',
+            '子控件和标签共享的行内样式。',
+          ),
+        },
+        {
+          name: 'onChange',
+          type: '(event: RadioChangeEvent) => void',
+          defaultValue: '—',
+          description: text(
+            'Reports the selected value and native event.',
+            '返回选中值和原生事件。',
+          ),
+        },
+      ],
+    },
+  },
+  slider: {
+    main: {
+      name: 'Slider',
+      inherited: text(
+        'Also accepts React HTML attributes for a div. The current slider is pointer-driven; add role, ARIA values, focus, and a keyboard handler when it is the only value editor.',
+        '同时接受 div 的 React HTML 属性。当前滑动条由指针驱动；当它是唯一数值编辑器时，请补充 role、ARIA 数值、焦点与键盘处理。',
+      ),
+      rows: [
+        {
+          name: 'value',
+          type: 'number',
+          defaultValue: '0',
+          description: text(
+            'Initial and externally synchronized value.',
+            '初始值，并可由外部同步更新。',
+          ),
+        },
+        {
+          name: 'min',
+          type: 'number',
+          defaultValue: '0',
+          description: text('Minimum value.', '最小值。'),
+        },
+        {
+          name: 'max',
+          type: 'number',
+          defaultValue: '100',
+          description: text('Maximum value.', '最大值。'),
+        },
+        {
+          name: 'step',
+          type: 'number',
+          defaultValue: '1',
+          description: text('Pointer increment.', '指针步进值。'),
+        },
+        {
+          name: 'disabled',
+          type: 'boolean',
+          defaultValue: 'false',
+          description: text('Disables pointer interaction.', '禁用指针交互。'),
+        },
+        {
+          name: 'vertical',
+          type: 'boolean',
+          defaultValue: 'false',
+          description: text('Uses vertical orientation.', '使用垂直方向。'),
+        },
+        {
+          name: 'bilateral',
+          type: 'boolean',
+          defaultValue: 'false',
+          description: text('Draws progress from the midpoint.', '从中点绘制进度。'),
+        },
+        {
+          name: 'hideThumb',
+          type: 'boolean',
+          defaultValue: 'false',
+          description: text('Hides the thumb.', '隐藏滑块。'),
+        },
+        {
+          name: 'hideThumbLabel',
+          type: 'boolean',
+          defaultValue: 'false',
+          description: text(
+            'Hides the value label shown while dragging.',
+            '隐藏拖动时显示的数值标签。',
+          ),
+        },
+        {
+          name: 'prohibitInteraction',
+          type: 'boolean',
+          defaultValue: 'false',
+          description: text(
+            'Makes the slider display-only without disabled styling.',
+            '让滑动条仅展示数值，但不显示禁用样式。',
+          ),
+        },
+        {
+          name: 'classNames',
+          type: '{ progress?: string; thumb?: string; thumbLabel?: string; axis?: string }',
+          defaultValue: '—',
+          description: text('Classes for named slider slots.', '各滑动条插槽的类名。'),
+        },
+        {
+          name: 'styles',
+          type: '{ progress?: CSSProperties; thumb?: CSSProperties; thumbLabel?: CSSProperties; axis?: CSSProperties }',
+          defaultValue: '—',
+          description: text('Inline styles for named slider slots.', '各滑动条插槽的行内样式。'),
+        },
+        {
+          name: 'axis',
+          type: 'boolean',
+          defaultValue: 'false',
+          description: text(
+            'Displays an Axis beneath or beside the track.',
+            '在轨道下方或旁边显示 Axis。',
+          ),
+        },
+        {
+          name: 'axisProps',
+          type: "Omit<AxisProps, 'className' | 'style'>",
+          defaultValue: '—',
+          description: text('Configures the optional Axis.', '配置可选的 Axis。'),
+        },
+        {
+          name: 'onChange',
+          type: '(value: number) => void',
+          defaultValue: '—',
+          description: text('Reports values while dragging.', '拖动时持续返回数值。'),
+        },
+        {
+          name: 'onChangeEnd',
+          type: '(value: number) => void',
+          defaultValue: '—',
+          description: text('Reports the final drag value.', '返回拖动结束时的最终值。'),
+        },
+      ],
+    },
+  },
+  switch: {
+    main: {
+      name: 'Switch',
+      inherited: text(
+        'Also accepts React.HTMLAttributes<HTMLLabelElement>. The base component renders spans rather than an input; add switch role, ARIA state, focus, and keyboard handling for standalone use.',
+        '同时接受 React.HTMLAttributes<HTMLLabelElement>。基础组件渲染 span 而非 input；独立使用时请补充 switch role、ARIA 状态、焦点与键盘处理。',
+      ),
+      rows: [
+        {
+          name: 'toggled',
+          type: 'boolean',
+          defaultValue: 'false',
+          description: text(
+            'Initial and externally synchronized on/off state.',
+            '初始开关状态，并可由外部同步更新。',
+          ),
+        },
+        {
+          name: 'disabled',
+          type: 'boolean',
+          defaultValue: 'false',
+          description: text('Disables pointer interaction.', '禁用指针交互。'),
+        },
+        {
+          name: 'size',
+          type: "'sm' | 'md' | 'lg'",
+          defaultValue: "'md'",
+          description: text('Track, thumb, and label size.', '轨道、滑块和标签尺寸。'),
+        },
+        {
+          name: 'classNames',
+          type: '{ label?: string; button?: string; thumb?: string }',
+          defaultValue: '—',
+          description: text('Classes for named switch slots.', '各开关插槽的类名。'),
+        },
+        {
+          name: 'styles',
+          type: '{ label?: CSSProperties; button?: CSSProperties; thumb?: CSSProperties }',
+          defaultValue: '—',
+          description: text('Inline styles for named switch slots.', '各开关插槽的行内样式。'),
+        },
+        {
+          name: 'onChange',
+          type: '(toggled: boolean) => void',
+          defaultValue: '—',
+          description: text(
+            'Runs on mount and after the internal state changes.',
+            '挂载时以及内部状态变化后调用。',
+          ),
+        },
+      ],
+    },
+  },
+}
+
+const labels = {
+  en: {
+    defaultValue: 'Default',
+    description: 'Description',
+    name: 'Prop',
+    required: 'required',
+    type: 'Type',
+  },
+  zh: {
+    defaultValue: '默认值',
+    description: '说明',
+    name: '属性',
+    required: '必填',
+    type: '类型',
+  },
+} as const
+
+type ApiTableProps = Readonly<{
+  lang: Locale
+  section: ApiSection
+}>
+
+const ApiTable: FC<ApiTableProps> = ({ lang, section }) => {
+  const localeLabels = labels[lang]
+
+  return (
+    <section className={styles.apiSection} aria-labelledby={`${section.name}-api`}>
+      <h3 className={styles.apiHeading} id={`${section.name}-api`}>
+        {section.name}
+      </h3>
+      <p className={styles.apiInherited}>{section.inherited[lang]}</p>
+      <div className={styles.tableWrap}>
+        <table className={styles.apiTable}>
+          <caption className={styles.visuallyHidden}>
+            {section.name} {lang === 'zh' ? '公开属性' : 'public props'}
+          </caption>
+          <thead>
+            <tr>
+              <th scope="col">{localeLabels.name}</th>
+              <th scope="col">{localeLabels.type}</th>
+              <th scope="col">{localeLabels.defaultValue}</th>
+              <th scope="col">{localeLabels.description}</th>
+            </tr>
+          </thead>
+          <tbody>
+            {section.rows.map((row) => (
+              <tr key={row.name}>
+                <td className={styles.propName} data-label={localeLabels.name}>
+                  <code>{row.name}</code>
+                  {row.required && (
+                    <span className={styles.required} title={localeLabels.required}>
+                      *
+                    </span>
+                  )}
+                </td>
+                <td data-label={localeLabels.type}>
+                  <code>{row.type}</code>
+                </td>
+                <td data-label={localeLabels.defaultValue}>
+                  <code>{row.defaultValue}</code>
+                </td>
+                <td data-label={localeLabels.description}>{row.description[lang]}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </section>
+  )
+}
+
+type ControllerApiProps = Readonly<{
+  controller: ControllerName
+  lang: Locale
+}>
+
+export const ControllerApi: FC<ControllerApiProps> = ({ controller, lang }) => {
+  const definition = definitions[controller]
+
+  return (
+    <div data-controller-api={controller}>
+      <ApiTable lang={lang} section={definition.main} />
+      {definition.group && <ApiTable lang={lang} section={definition.group} />}
+    </div>
+  )
+}

--- a/docs-nextra/app/_components/controller-demo.tsx
+++ b/docs-nextra/app/_components/controller-demo.tsx
@@ -1,0 +1,347 @@
+'use client'
+
+import {
+  Button,
+  Checkbox,
+  Envelope,
+  Input,
+  Knob,
+  Radio,
+  Slider,
+  Switch,
+  type EnvelopeData,
+} from '@nafr/echo-ui'
+import type { FC, KeyboardEvent, ReactNode } from 'react'
+import { useState } from 'react'
+import type { ControllerName } from './controller-api'
+import styles from './controller-docs.module.css'
+
+type Locale = 'en' | 'zh'
+
+type DemoFrameProps = Readonly<{
+  children: ReactNode
+  controller: ControllerName
+  lang: Locale
+  status: string
+  tall?: boolean
+}>
+
+const DemoFrame: FC<DemoFrameProps> = ({ children, controller, lang, status, tall }) => (
+  <section className={styles.demo} data-controller-demo={controller}>
+    <header className={styles.demoHeader}>
+      <span className={styles.demoLabel}>{lang === 'zh' ? '实时控件' : 'Live control'}</span>
+      <p className={styles.demoStatus} aria-live="polite">
+        {status}
+      </p>
+    </header>
+    <div className={`${styles.demoSurface} ${tall ? styles.demoSurfaceTall : ''}`}>{children}</div>
+  </section>
+)
+
+const ButtonDemo: FC<{ lang: Locale }> = ({ lang }) => {
+  const [auditioning, setAuditioning] = useState(false)
+  const [waveform, setWaveform] = useState('sine')
+
+  return (
+    <DemoFrame
+      controller="button"
+      lang={lang}
+      status={
+        lang === 'zh'
+          ? `${auditioning ? '试听中' : '已停止'} · 波形：${waveform}`
+          : `${auditioning ? 'Auditioning' : 'Stopped'} · Wave: ${waveform}`
+      }
+    >
+      <div className={styles.demoStack}>
+        <div className={styles.demoRow}>
+          <Button
+            aria-pressed={auditioning}
+            toggled={auditioning}
+            onClick={() => setAuditioning((current) => !current)}
+          >
+            {lang === 'zh' ? '试听音色' : 'Audition sound'}
+          </Button>
+        </div>
+        <Button.Group
+          aria-label={lang === 'zh' ? '波形' : 'Waveform'}
+          role="group"
+          value={waveform}
+          onChange={(nextValue) => setWaveform(String(nextValue))}
+        >
+          <Button value="sine">Sine</Button>
+          <Button value="triangle">Triangle</Button>
+          <Button value="square">Square</Button>
+        </Button.Group>
+      </div>
+    </DemoFrame>
+  )
+}
+
+const CheckboxDemo: FC<{ lang: Locale }> = ({ lang }) => {
+  const [effects, setEffects] = useState<unknown[]>(['delay'])
+
+  return (
+    <DemoFrame
+      controller="checkbox"
+      lang={lang}
+      status={
+        lang === 'zh'
+          ? `已启用：${effects.length ? effects.join('、') : '无'}`
+          : `Enabled: ${effects.length ? effects.join(', ') : 'none'}`
+      }
+    >
+      <Checkbox.Group
+        aria-label={lang === 'zh' ? '效果器' : 'Effects'}
+        role="group"
+        value={effects}
+        onChange={(event) => setEffects(event.value as unknown[])}
+      >
+        <Checkbox value="delay">Delay</Checkbox>
+        <Checkbox value="chorus">Chorus</Checkbox>
+        <Checkbox value="reverb">Reverb</Checkbox>
+      </Checkbox.Group>
+    </DemoFrame>
+  )
+}
+
+const initialEnvelope: EnvelopeData = {
+  attack: 0.16,
+  decay: 0.28,
+  sustain: 0.58,
+  release: 0.45,
+}
+
+const envelopeFields: Array<keyof EnvelopeData> = ['attack', 'decay', 'sustain', 'release']
+
+const EnvelopeDemo: FC<{ lang: Locale }> = ({ lang }) => {
+  const [data, setData] = useState<EnvelopeData>(initialEnvelope)
+
+  const updateField = (field: keyof EnvelopeData, value: number) => {
+    setData((current) => ({ ...current, [field]: value }))
+  }
+
+  return (
+    <DemoFrame
+      controller="envelope"
+      lang={lang}
+      status={`A ${data.attack.toFixed(2)} · D ${data.decay.toFixed(2)} · S ${data.sustain.toFixed(2)} · R ${data.release.toFixed(2)}`}
+      tall
+    >
+      <div className={styles.demoStack}>
+        <div className={styles.envelope} aria-hidden="true">
+          <Envelope data={data} onChange={setData} />
+        </div>
+        <div className={styles.envelopeFields}>
+          {envelopeFields.map((field) => (
+            <label className={styles.demoField} key={field}>
+              <span>{field}</span>
+              <input
+                aria-label={field}
+                max={field === 'sustain' ? 1 : undefined}
+                min={0}
+                step={0.01}
+                type="number"
+                value={data[field]}
+                onChange={(event) => updateField(field, Number(event.target.value))}
+              />
+            </label>
+          ))}
+        </div>
+      </div>
+    </DemoFrame>
+  )
+}
+
+const InputDemo: FC<{ lang: Locale }> = ({ lang }) => {
+  const [gain, setGain] = useState<number | string>(-6)
+
+  return (
+    <DemoFrame
+      controller="input"
+      lang={lang}
+      status={lang === 'zh' ? `增益：${gain} dB` : `Gain: ${gain} dB`}
+    >
+      <label className={styles.demoField}>
+        <span>{lang === 'zh' ? '增益（可输入或上下拖动）' : 'Gain (type or drag vertically)'}</span>
+        <Input
+          aria-label={lang === 'zh' ? '增益' : 'Gain'}
+          bilateral
+          max={12}
+          min={-60}
+          step={0.5}
+          value={gain}
+          onChange={(event) => setGain(event.value)}
+        />
+      </label>
+    </DemoFrame>
+  )
+}
+
+const KnobDemo: FC<{ lang: Locale }> = ({ lang }) => {
+  const [gain, setGain] = useState(-3)
+  const [pan, setPan] = useState(0)
+
+  return (
+    <DemoFrame
+      controller="knob"
+      lang={lang}
+      status={lang === 'zh' ? `增益 ${gain} dB · 声像 ${pan}` : `Gain ${gain} dB · Pan ${pan}`}
+      tall
+    >
+      <div className={styles.demoStack}>
+        <Knob.Group size="5rem" step={1}>
+          <Knob
+            bottomLabel={`${gain} dB`}
+            max={12}
+            min={-60}
+            topLabel={lang === 'zh' ? '增益' : 'Gain'}
+            value={gain}
+            onChange={setGain}
+          />
+          <Knob
+            bilateral
+            bottomLabel={`${pan}`}
+            max={50}
+            min={-50}
+            topLabel={lang === 'zh' ? '声像' : 'Pan'}
+            value={pan}
+            onChange={setPan}
+          />
+        </Knob.Group>
+        <label className={styles.demoField}>
+          <span>
+            {lang === 'zh' ? '键盘可用的增益镜像输入' : 'Keyboard-accessible gain mirror'}
+          </span>
+          <input
+            aria-label={lang === 'zh' ? '增益镜像输入' : 'Gain mirror input'}
+            max={12}
+            min={-60}
+            step={1}
+            type="range"
+            value={gain}
+            onChange={(event) => setGain(Number(event.target.value))}
+          />
+        </label>
+      </div>
+    </DemoFrame>
+  )
+}
+
+const RadioDemo: FC<{ lang: Locale }> = ({ lang }) => {
+  const [quality, setQuality] = useState('balanced')
+
+  return (
+    <DemoFrame
+      controller="radio"
+      lang={lang}
+      status={lang === 'zh' ? `渲染质量：${quality}` : `Render quality: ${quality}`}
+    >
+      <Radio.Group
+        aria-label={lang === 'zh' ? '渲染质量' : 'Render quality'}
+        role="radiogroup"
+        value={quality}
+        onChange={(event) => setQuality(String(event.value))}
+      >
+        <Radio value="draft">{lang === 'zh' ? '草稿' : 'Draft'}</Radio>
+        <Radio value="balanced">{lang === 'zh' ? '均衡' : 'Balanced'}</Radio>
+        <Radio value="studio">{lang === 'zh' ? '录音室' : 'Studio'}</Radio>
+      </Radio.Group>
+    </DemoFrame>
+  )
+}
+
+const SliderDemo: FC<{ lang: Locale }> = ({ lang }) => {
+  const [mix, setMix] = useState(35)
+
+  const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+    const change = event.key === 'ArrowRight' || event.key === 'ArrowUp' ? 5 : -5
+    if (!['ArrowRight', 'ArrowUp', 'ArrowLeft', 'ArrowDown'].includes(event.key)) return
+    event.preventDefault()
+    setMix((current) => Math.min(100, Math.max(0, current + change)))
+  }
+
+  return (
+    <DemoFrame
+      controller="slider"
+      lang={lang}
+      status={lang === 'zh' ? `干湿比：${mix}%` : `Wet mix: ${mix}%`}
+    >
+      <div className={styles.demoStack}>
+        <Slider
+          aria-label={lang === 'zh' ? '干湿比' : 'Wet mix'}
+          aria-valuemax={100}
+          aria-valuemin={0}
+          aria-valuenow={mix}
+          axis
+          className={styles.slider}
+          max={100}
+          min={0}
+          role="slider"
+          tabIndex={0}
+          value={mix}
+          onChange={setMix}
+          onKeyDown={handleKeyDown}
+        />
+      </div>
+    </DemoFrame>
+  )
+}
+
+const SwitchDemo: FC<{ lang: Locale }> = ({ lang }) => {
+  const [bypassed, setBypassed] = useState(false)
+
+  const handleKeyDown = (event: KeyboardEvent<HTMLLabelElement>) => {
+    if (event.key !== ' ' && event.key !== 'Enter') return
+    event.preventDefault()
+    setBypassed((current) => !current)
+  }
+
+  return (
+    <DemoFrame
+      controller="switch"
+      lang={lang}
+      status={
+        lang === 'zh'
+          ? `效果器：${bypassed ? '已旁通' : '处理中'}`
+          : `Effect: ${bypassed ? 'bypassed' : 'processing'}`
+      }
+    >
+      <Switch
+        aria-checked={bypassed}
+        role="switch"
+        tabIndex={0}
+        toggled={bypassed}
+        onChange={setBypassed}
+        onKeyDown={handleKeyDown}
+      >
+        {lang === 'zh' ? '旁通效果器' : 'Bypass effect'}
+      </Switch>
+    </DemoFrame>
+  )
+}
+
+type ControllerDemoProps = Readonly<{
+  controller: ControllerName
+  lang: Locale
+}>
+
+export const ControllerDemo: FC<ControllerDemoProps> = ({ controller, lang }) => {
+  switch (controller) {
+    case 'button':
+      return <ButtonDemo lang={lang} />
+    case 'checkbox':
+      return <CheckboxDemo lang={lang} />
+    case 'envelope':
+      return <EnvelopeDemo lang={lang} />
+    case 'input':
+      return <InputDemo lang={lang} />
+    case 'knob':
+      return <KnobDemo lang={lang} />
+    case 'radio':
+      return <RadioDemo lang={lang} />
+    case 'slider':
+      return <SliderDemo lang={lang} />
+    case 'switch':
+      return <SwitchDemo lang={lang} />
+  }
+}

--- a/docs-nextra/app/_components/controller-docs.module.css
+++ b/docs-nextra/app/_components/controller-docs.module.css
@@ -1,0 +1,387 @@
+.install {
+  align-items: start;
+  background: oklch(97% 0.018 78);
+  border: 1px solid oklch(87% 0.045 78);
+  border-radius: 0.9rem;
+  display: grid;
+  gap: 0.5rem 1rem;
+  grid-template-columns: auto minmax(0, 1fr);
+  margin-block: 1.5rem 2rem;
+  padding: 1rem 1.25rem;
+}
+
+.installBadge {
+  background: oklch(69% 0.17 66);
+  border-radius: 999px;
+  color: oklch(22% 0.045 66);
+  font-size: 0.75rem;
+  font-weight: 750;
+  letter-spacing: 0.08em;
+  line-height: 1.5rem;
+  padding-inline: 0.65rem;
+  text-transform: uppercase;
+}
+
+.installCopy {
+  color: oklch(31% 0.025 66);
+  font-size: 0.9rem;
+  line-height: 1.5;
+  margin: 0;
+}
+
+.installCommand {
+  background: oklch(92% 0.025 78);
+  border-radius: 0.35rem;
+  color: oklch(25% 0.035 66);
+  display: inline-block;
+  font-size: 0.85rem;
+  grid-column: 2;
+  line-height: 1.5;
+  overflow-wrap: anywhere;
+  padding: 0.35rem 0.55rem;
+}
+
+.demo {
+  background:
+    linear-gradient(oklch(98% 0.008 74 / 94%), oklch(98% 0.008 74 / 94%)),
+    radial-gradient(circle at 1px 1px, oklch(67% 0.04 74) 1px, transparent 0);
+  background-size:
+    auto,
+    1rem 1rem;
+  border: 1px solid oklch(87% 0.025 74);
+  border-radius: 1.1rem;
+  container-type: inline-size;
+  margin-block: 1.5rem 2rem;
+  overflow: clip;
+}
+
+.demoHeader {
+  align-items: center;
+  border-bottom: 1px solid oklch(88% 0.025 74);
+  display: flex;
+  gap: 0.75rem;
+  justify-content: space-between;
+  padding: 0.7rem 1rem;
+}
+
+.demoLabel {
+  color: oklch(38% 0.035 65);
+  font-size: 0.72rem;
+  font-weight: 750;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.demoStatus {
+  color: oklch(42% 0.025 65);
+  font-size: 0.82rem;
+  font-variant-numeric: tabular-nums;
+  line-height: 1.4;
+  margin: 0;
+  text-align: right;
+}
+
+.demoSurface {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.25rem;
+  justify-content: center;
+  min-height: 10rem;
+  padding: clamp(1.5rem, 6cqi, 3.5rem);
+}
+
+.demoSurfaceTall {
+  min-height: 16rem;
+}
+
+.demoStack {
+  align-items: stretch;
+  display: grid;
+  gap: 1rem;
+  max-width: 32rem;
+  width: 100%;
+}
+
+.demoRow {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  justify-content: center;
+}
+
+.demoField {
+  display: grid;
+  gap: 0.4rem;
+  min-width: min(100%, 10rem);
+}
+
+.demoField > span {
+  color: oklch(42% 0.025 65);
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+}
+
+.envelope {
+  height: 11rem;
+  width: 100%;
+}
+
+.envelopeFields {
+  display: grid;
+  gap: 0.75rem;
+  grid-template-columns: repeat(auto-fit, minmax(6rem, 1fr));
+}
+
+.envelopeFields input {
+  background: var(--echo-input);
+  border: 1px solid oklch(76% 0.035 70);
+  border-radius: 0.45rem;
+  color: var(--echo-foreground);
+  font: inherit;
+  min-width: 0;
+  padding: 0.45rem 0.55rem;
+  width: 100%;
+}
+
+.envelopeFields input:focus-visible {
+  outline: 2px solid oklch(69% 0.17 66);
+  outline-offset: 2px;
+}
+
+.slider {
+  margin-block: 1.75rem 0.75rem;
+  width: 100%;
+}
+
+.apiSection {
+  margin-block: 1.25rem 2.5rem;
+}
+
+.apiSection + .apiSection {
+  border-top: 1px solid oklch(88% 0.025 74);
+  padding-top: 1.75rem;
+}
+
+.apiHeading {
+  color: inherit;
+  font-size: 1.05rem;
+  font-weight: 750;
+  letter-spacing: -0.015em;
+  margin: 0 0 0.75rem;
+}
+
+.apiInherited {
+  color: oklch(43% 0.02 70);
+  font-size: 0.88rem;
+  line-height: 1.55;
+  margin: 0 0 1rem;
+}
+
+.tableWrap {
+  border: 1px solid oklch(87% 0.025 74);
+  border-radius: 0.8rem;
+  overflow: hidden;
+}
+
+.apiTable {
+  border-collapse: collapse;
+  font-size: 0.86rem;
+  line-height: 1.5;
+  margin: 0;
+  width: 100%;
+}
+
+.apiTable th,
+.apiTable td {
+  border: 0;
+  border-bottom: 1px solid oklch(90% 0.018 74);
+  padding: 0.75rem 0.85rem;
+  text-align: left;
+  vertical-align: top;
+}
+
+.apiTable th {
+  background: oklch(95% 0.018 74);
+  color: oklch(34% 0.03 68);
+  font-size: 0.72rem;
+  font-weight: 750;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+}
+
+.apiTable tr:last-child td {
+  border-bottom: 0;
+}
+
+.apiTable code {
+  background: oklch(93% 0.02 74);
+  border-radius: 0.3rem;
+  color: oklch(31% 0.04 63);
+  font-size: 0.8rem;
+  overflow-wrap: anywhere;
+  padding: 0.12rem 0.3rem;
+  white-space: normal;
+}
+
+.propName {
+  font-weight: 700;
+  white-space: nowrap;
+}
+
+.required {
+  color: oklch(55% 0.19 35);
+  margin-left: 0.15rem;
+}
+
+.visuallyHidden {
+  clip: rect(0 0 0 0);
+  clip-path: inset(50%);
+  height: 1px;
+  overflow: hidden;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+:global(.dark) .install {
+  background: oklch(23% 0.025 67);
+  border-color: oklch(38% 0.045 67);
+}
+
+:global(.dark) .installCopy,
+:global(.dark) .installCommand {
+  color: oklch(88% 0.025 75);
+}
+
+:global(.dark) .installCommand {
+  background: oklch(29% 0.03 67);
+}
+
+:global(.dark) .demo {
+  background:
+    linear-gradient(oklch(19% 0.012 70 / 94%), oklch(19% 0.012 70 / 94%)),
+    radial-gradient(circle at 1px 1px, oklch(42% 0.035 70) 1px, transparent 0);
+  background-size:
+    auto,
+    1rem 1rem;
+  border-color: oklch(32% 0.025 70);
+}
+
+:global(.dark) .demoHeader,
+:global(.dark) .apiSection + .apiSection {
+  border-color: oklch(32% 0.025 70);
+}
+
+:global(.dark) .demoLabel,
+:global(.dark) .demoStatus,
+:global(.dark) .demoField > span,
+:global(.dark) .apiInherited {
+  color: oklch(77% 0.035 72);
+}
+
+:global(.dark) .tableWrap {
+  border-color: oklch(32% 0.025 70);
+}
+
+:global(.dark) .apiTable th {
+  background: oklch(24% 0.02 70);
+  color: oklch(82% 0.035 72);
+}
+
+:global(.dark) .apiTable th,
+:global(.dark) .apiTable td {
+  border-bottom-color: oklch(30% 0.02 70);
+}
+
+:global(.dark) .apiTable code {
+  background: oklch(27% 0.025 70);
+  color: oklch(88% 0.04 75);
+}
+
+@container (max-width: 32rem) {
+  .demoHeader {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .demoStatus {
+    text-align: left;
+  }
+
+  .demoSurface {
+    justify-content: flex-start;
+  }
+}
+
+@media (max-width: 640px) {
+  .install {
+    grid-template-columns: 1fr;
+  }
+
+  .installBadge {
+    justify-self: start;
+  }
+
+  .installCommand {
+    grid-column: 1;
+  }
+
+  .tableWrap {
+    border: 0;
+    overflow: visible;
+  }
+
+  .apiTable,
+  .apiTable tbody,
+  .apiTable tr,
+  .apiTable td {
+    display: block;
+  }
+
+  .apiTable thead {
+    display: none;
+  }
+
+  .apiTable tr {
+    border: 1px solid oklch(87% 0.025 74);
+    border-radius: 0.7rem;
+    margin-bottom: 0.75rem;
+    overflow: hidden;
+  }
+
+  .apiTable td {
+    border-bottom: 1px solid oklch(90% 0.018 74);
+    display: grid;
+    gap: 0.25rem;
+    grid-template-columns: minmax(5rem, 0.34fr) minmax(0, 1fr);
+  }
+
+  .apiTable td::before {
+    color: oklch(46% 0.025 70);
+    content: attr(data-label);
+    font-size: 0.68rem;
+    font-weight: 750;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+  }
+
+  :global(.dark) .apiTable tr {
+    border-color: oklch(32% 0.025 70);
+  }
+
+  :global(.dark) .apiTable td::before {
+    color: oklch(72% 0.03 72);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .demo *,
+  .demo *::before,
+  .demo *::after {
+    scroll-behavior: auto !important;
+    transition-duration: 0.01ms !important;
+  }
+}

--- a/docs-nextra/app/_components/install-package.tsx
+++ b/docs-nextra/app/_components/install-package.tsx
@@ -1,0 +1,19 @@
+import type { FC } from 'react'
+import styles from './controller-docs.module.css'
+
+type InstallPackageProps = Readonly<{
+  lang: 'en' | 'zh'
+}>
+
+const copy = {
+  en: 'Install the package, then import its stylesheet once in your application entry point.',
+  zh: '安装软件包，然后在应用入口文件中引入一次样式表。',
+} as const
+
+export const InstallPackage: FC<InstallPackageProps> = ({ lang }) => (
+  <aside className={styles.install} aria-label={lang === 'zh' ? '安装' : 'Installation'}>
+    <span className={styles.installBadge}>{lang === 'zh' ? '安装' : 'Package'}</span>
+    <p className={styles.installCopy}>{copy[lang]}</p>
+    <code className={styles.installCommand}>pnpm add @nafr/echo-ui</code>
+  </aside>
+)

--- a/docs-nextra/content/en/_meta.ts
+++ b/docs-nextra/content/en/_meta.ts
@@ -19,6 +19,11 @@ const meta: MetaRecord = {
     title: 'Guide',
     type: 'page',
   },
+  component: {
+    href: '/en/component/button/',
+    title: 'Controllers',
+    type: 'page',
+  },
   community: {
     items: {
       discussions: {

--- a/docs-nextra/content/en/component/_meta.ts
+++ b/docs-nextra/content/en/component/_meta.ts
@@ -1,0 +1,14 @@
+import type { MetaRecord } from 'nextra'
+
+const meta: MetaRecord = {
+  button: 'Button',
+  checkbox: 'Checkbox',
+  envelope: 'Envelope',
+  input: 'Input',
+  knob: 'Knob',
+  radio: 'Radio',
+  slider: 'Slider',
+  switch: 'Switch',
+}
+
+export default meta

--- a/docs-nextra/content/en/component/button.mdx
+++ b/docs-nextra/content/en/component/button.mdx
@@ -1,0 +1,52 @@
+---
+title: Button
+description: Render pressable and grouped audio controls with Echo UI Button.
+---
+
+import { ControllerApi } from '@/app/_components/controller-api'
+import { ControllerDemo } from '@/app/_components/controller-demo'
+import { InstallPackage } from '@/app/_components/install-package'
+
+# Button
+
+Use `Button` for momentary actions, visually pressed controls, and compact single- or multi-select groups.
+
+<InstallPackage lang="en" />
+
+```tsx
+import '@nafr/echo-ui/style.css'
+import { Button } from '@nafr/echo-ui'
+
+export function AuditionButton() {
+  return <Button onClick={() => audition()}>Audition sound</Button>
+}
+```
+
+## Live example
+
+The first button keeps its `toggled` state in React. The group is a controlled single-select field: click a waveform and the parent writes the next `value` back.
+
+<ControllerDemo controller="button" lang="en" />
+
+## State and grouping
+
+A standalone `Button` does not invert `toggled` when clicked. Treat `toggled` as a visual state and update it from `onClick` (or another application event). `onToggleChange` observes the effective state after render; it is not the click event.
+
+`Button.Group` compares each child `value` with the group's `value`. Pass one value for single selection or an array for multi-selection. In both modes the group is controlled, so persist the value returned by `onChange`.
+
+```tsx
+const [waveform, setWaveform] = useState('sine')
+
+<Button.Group value={waveform} onChange={setWaveform} role="group" aria-label="Waveform">
+  <Button value="sine">Sine</Button>
+  <Button value="square">Square</Button>
+</Button.Group>
+```
+
+## Accessibility
+
+`Button` renders a native `<button>`, so it is focusable and activates with Enter or Space. Supply an accessible name through its children or `aria-label`. For a toggle button, keep `aria-pressed` synchronized with `toggled`. `Button.Group` is a layout `<div>`; add `role="group"` and a label when its members form one named control.
+
+## API
+
+<ControllerApi controller="button" lang="en" />

--- a/docs-nextra/content/en/component/checkbox.mdx
+++ b/docs-nextra/content/en/component/checkbox.mdx
@@ -1,0 +1,52 @@
+---
+title: Checkbox
+description: Choose multiple audio options with Echo UI Checkbox and Checkbox.Group.
+---
+
+import { ControllerApi } from '@/app/_components/controller-api'
+import { ControllerDemo } from '@/app/_components/controller-demo'
+import { InstallPackage } from '@/app/_components/install-package'
+
+# Checkbox
+
+Use `Checkbox` for independent Boolean options or `Checkbox.Group` for a set of effects, channels, or capabilities that may be enabled together.
+
+<InstallPackage lang="en" />
+
+```tsx
+import '@nafr/echo-ui/style.css'
+import { Checkbox } from '@nafr/echo-ui'
+
+export function NormalizeOption() {
+  return <Checkbox>Normalize output</Checkbox>
+}
+```
+
+## Live example
+
+This controlled group writes the array from `event.value` back to `value`.
+
+<ControllerDemo controller="checkbox" lang="en" />
+
+## Controlled and standalone use
+
+Without a group, the component keeps a local checked state initialized from `checked`; it also synchronizes when `checked` changes. `onChange` receives `{ value, nativeEvent }`, where `value` is the next Boolean.
+
+Inside `Checkbox.Group`, each child reports its own `value` and the group reports the next array. Keep that array in the parent for reliable group state.
+
+```tsx
+const [effects, setEffects] = useState(['delay'])
+
+<Checkbox.Group value={effects} onChange={(event) => setEffects(event.value)} role="group">
+  <Checkbox value="delay">Delay</Checkbox>
+  <Checkbox value="reverb">Reverb</Checkbox>
+</Checkbox.Group>
+```
+
+## Accessibility
+
+Each checkbox contains a native `input[type="checkbox"]`, and its children become the visible label. That provides focus, Space-key activation, and checked semantics. Give the group wrapper `role="group"` plus `aria-label` or `aria-labelledby` when the set needs a shared name. The current public type is `React.HTMLAttributes<HTMLInputElement>`, so input-only attributes such as `name` are not exposed.
+
+## API
+
+<ControllerApi controller="checkbox" lang="en" />

--- a/docs-nextra/content/en/component/envelope.mdx
+++ b/docs-nextra/content/en/component/envelope.mdx
@@ -1,0 +1,59 @@
+---
+title: Envelope
+description: Edit ADSR, AHDSR, and DADSR shapes with Echo UI Envelope.
+---
+
+import { ControllerApi } from '@/app/_components/controller-api'
+import { ControllerDemo } from '@/app/_components/controller-demo'
+import { InstallPackage } from '@/app/_components/install-package'
+
+# Envelope
+
+`Envelope` visualizes an amplitude envelope and lets a pointer edit each stage. Use ADSR data by default; add `hold` for AHDSR and `delay` plus `hold` for DADSR.
+
+<InstallPackage lang="en" />
+
+```tsx
+import '@nafr/echo-ui/style.css'
+import { Envelope, type EnvelopeData } from '@nafr/echo-ui'
+
+const initial: EnvelopeData = {
+  attack: 0.1,
+  decay: 0.3,
+  sustain: 0.65,
+  release: 0.5,
+}
+```
+
+## Live example
+
+Drag the SVG nodes or edit the equivalent native fields. Both paths update the same controlled `data` object.
+
+<ControllerDemo controller="envelope" lang="en" />
+
+## Data and limits
+
+`data` is required. Time stages use seconds (or any consistent duration unit); `sustain` is normalized from `0` to `1`. `limits` sets the maximum draggable duration for each time stage. If `delay` or `hold` is absent from `data`, that stage is removed and its limit becomes zero.
+
+```tsx
+const [data, setData] = useState(initial)
+
+<div style={{ width: 480, height: 220 }}>
+  <Envelope
+    data={data}
+    limits={{ attack: 2, decay: 2, release: 4 }}
+    onChange={setData}
+    onChangeEnd={(finalData) => saveEnvelope(finalData)}
+  />
+</div>
+```
+
+Give the parent an explicit size: the component fills its container. `onChange` runs while a node moves and `onChangeEnd` runs after the drag finishes.
+
+## Accessibility
+
+The envelope graph is an SVG pointer editor and currently exposes no keyboard-operable control semantics. Treat it as a visualization and provide native labeled inputs for the same stage values, as the live example does. Keep the graph `aria-hidden` when the native fields are the accessible editing surface, and announce important saved-state changes separately.
+
+## API
+
+<ControllerApi controller="envelope" lang="en" />

--- a/docs-nextra/content/en/component/input.mdx
+++ b/docs-nextra/content/en/component/input.mdx
@@ -1,0 +1,57 @@
+---
+title: Input
+description: Enter or drag audio parameter values with Echo UI Input.
+---
+
+import { ControllerApi } from '@/app/_components/controller-api'
+import { ControllerDemo } from '@/app/_components/controller-demo'
+import { InstallPackage } from '@/app/_components/install-package'
+
+# Input
+
+`Input` supports ordinary text entry and bounded numeric entry. Numeric inputs also respond to vertical pointer dragging and display their position as a progress fill.
+
+<InstallPackage lang="en" />
+
+```tsx
+import '@nafr/echo-ui/style.css'
+import { Input } from '@nafr/echo-ui'
+
+export function TrackName() {
+  return <Input type="text" aria-label="Track name" value="Lead synth" />
+}
+```
+
+## Live example
+
+Type a gain value, or drag vertically after moving more than 20 pixels. The bilateral fill grows away from the range midpoint (`-24`) in this `-60` to `12` range.
+
+<ControllerDemo controller="input" lang="en" />
+
+## Value behavior
+
+The component keeps local state, initializes to `0`, and synchronizes when `value` changes. For application state, pass `value` and store `event.value` from `onChange`. Numeric values are clamped to `min` and `max`; dragging snaps to `step` and is scaled by `sensitivity`.
+
+```tsx
+const [gain, setGain] = useState(-6)
+
+<Input
+  aria-label="Gain in decibels"
+  bilateral
+  min={-60}
+  max={12}
+  step={0.5}
+  value={gain}
+  onChange={(event) => setGain(Number(event.value))}
+/>
+```
+
+Set `prohibitDrag` when normal text selection or touch behavior matters more than drag editing. `hideProgress` removes the fill without changing value behavior.
+
+## Accessibility
+
+`Input` renders a native `<input>`, so use standard labeling with `<label>`, `aria-label`, or `aria-labelledby`. Numeric typing retains the browser's keyboard behavior. Pointer dragging is an enhancement and must not be the only way to edit the value. Keep visible units in the label rather than relying on the progress color.
+
+## API
+
+<ControllerApi controller="input" lang="en" />

--- a/docs-nextra/content/en/component/knob.mdx
+++ b/docs-nextra/content/en/component/knob.mdx
@@ -1,0 +1,50 @@
+---
+title: Knob
+description: Build rotary audio controls and parameter banks with Echo UI Knob.
+---
+
+import { ControllerApi } from '@/app/_components/controller-api'
+import { ControllerDemo } from '@/app/_components/controller-demo'
+import { InstallPackage } from '@/app/_components/install-package'
+
+# Knob
+
+`Knob` maps vertical pointer movement to a rotary display. `Knob.Group` shares range, sensitivity, dimensions, and colors across a bank while each child keeps its own value callbacks.
+
+<InstallPackage lang="en" />
+
+```tsx
+import '@nafr/echo-ui/style.css'
+import { Knob } from '@nafr/echo-ui'
+
+export function GainKnob() {
+  return <Knob min={-60} max={12} value={-6} topLabel="Gain" bottomLabel="-6 dB" />
+}
+```
+
+## Live example
+
+Drag upward or downward on either knob. The native range below mirrors Gain so keyboard and assistive-technology users can edit the same state.
+
+<ControllerDemo controller="knob" lang="en" />
+
+## Values and groups
+
+The value defaults to `0`, is clamped to `min` and `max`, and snaps to `step` while dragging. `rotationRange` is clamped between 90 and 360 degrees. `bilateral` draws progress from the midpoint, which suits pan and bipolar modulation.
+
+```tsx
+<Knob.Group size="5rem" min={-50} max={50} bilateral>
+  <Knob value={panA} onChange={setPanA} topLabel="Channel A" />
+  <Knob value={panB} onChange={setPanB} topLabel="Channel B" />
+</Knob.Group>
+```
+
+Group props are defaults: an explicit prop on a child wins. `value`, `onChange`, `onChangeEnd`, `topLabel`, and `bottomLabel` remain per-knob.
+
+## Accessibility
+
+The visual trigger has `role="slider"`, but the current component does not provide an accessible name, ARIA values, focus, or keyboard handling on that trigger. Do not use it as the only value editor in an accessible form. Pair it with a labeled native range or number input bound to the same state, as shown above.
+
+## API
+
+<ControllerApi controller="knob" lang="en" />

--- a/docs-nextra/content/en/component/radio.mdx
+++ b/docs-nextra/content/en/component/radio.mdx
@@ -1,0 +1,56 @@
+---
+title: Radio
+description: Choose one audio option with Echo UI Radio and Radio.Group.
+---
+
+import { ControllerApi } from '@/app/_components/controller-api'
+import { ControllerDemo } from '@/app/_components/controller-demo'
+import { InstallPackage } from '@/app/_components/install-package'
+
+# Radio
+
+Use `Radio.Group` when exactly one option should be active, such as a render quality, oscillator mode, or monitoring source.
+
+<InstallPackage lang="en" />
+
+```tsx
+import '@nafr/echo-ui/style.css'
+import { Radio } from '@nafr/echo-ui'
+
+export function QualityChoice() {
+  return <Radio checked>Balanced</Radio>
+}
+```
+
+## Live example
+
+The group keeps its selected option in React state and reports the next option through `event.value`.
+
+<ControllerDemo controller="radio" lang="en" />
+
+## Controlled grouping
+
+A standalone radio initializes from `checked` and can synchronize from later `checked` props. `Radio.Group` is controlled: it compares the group's `value` with each child `value`, so update the group value from `onChange`.
+
+```tsx
+const [quality, setQuality] = useState('balanced')
+
+<Radio.Group
+  role="radiogroup"
+  aria-label="Render quality"
+  value={quality}
+  onChange={(event) => setQuality(event.value)}
+>
+  <Radio value="draft">Draft</Radio>
+  <Radio value="balanced">Balanced</Radio>
+  <Radio value="studio">Studio</Radio>
+</Radio.Group>
+```
+
+## Accessibility
+
+Each item contains a native `input[type="radio"]`, so it is focusable and Space activates it. The group wrapper is a plain `<div>`; add `role="radiogroup"` and an accessible name. `RadioProps` currently does not expose the native `name` attribute, so the component cannot establish a browser-native named radio set through its public type; document this limitation in forms that require arrow-key group navigation.
+
+## API
+
+<ControllerApi controller="radio" lang="en" />

--- a/docs-nextra/content/en/component/slider.mdx
+++ b/docs-nextra/content/en/component/slider.mdx
@@ -1,0 +1,57 @@
+---
+title: Slider
+description: Display and edit continuous audio values with Echo UI Slider.
+---
+
+import { ControllerApi } from '@/app/_components/controller-api'
+import { ControllerDemo } from '@/app/_components/controller-demo'
+import { InstallPackage } from '@/app/_components/install-package'
+
+# Slider
+
+`Slider` turns pointer position into a bounded numeric value. It supports horizontal and vertical tracks, bipolar progress, optional axes, and display-only modes.
+
+<InstallPackage lang="en" />
+
+```tsx
+import '@nafr/echo-ui/style.css'
+import { Slider } from '@nafr/echo-ui'
+
+export function MixSlider() {
+  return <Slider min={0} max={100} value={35} />
+}
+```
+
+## Live example
+
+Drag the track, or focus it and use an arrow key. The example adds the ARIA and keyboard behavior required around the pointer-driven base component.
+
+<ControllerDemo controller="slider" lang="en" />
+
+## Value behavior
+
+The value defaults to `0`, is clamped between `min` and `max`, and snaps to `step`. The component updates local state while dragging and synchronizes when `value` changes. Persist `onChange` for application state and use `onChangeEnd` for work that should run once, such as committing automation.
+
+`bilateral` draws progress from the midpoint. `prohibitInteraction` preserves normal colors for a display-only meter; `disabled` also blocks interaction but uses disabled styling. `axis` renders an Echo UI `Axis` configured by `axisProps`.
+
+```tsx
+<Slider
+  role="slider"
+  tabIndex={0}
+  aria-label="Wet mix"
+  aria-valuemin={0}
+  aria-valuemax={100}
+  aria-valuenow={mix}
+  value={mix}
+  onChange={setMix}
+  onKeyDown={handleArrowKeys}
+/>
+```
+
+## Accessibility
+
+The base component renders a pointer-operated `<div>` without slider semantics or keyboard behavior. When it is the only editor, add `role="slider"`, a focus target, an accessible name, current/min/max ARIA values, and arrow-key handling. Alternatively pair the visualization with a native `input[type="range"]`. Never rely on progress color alone to communicate the value.
+
+## API
+
+<ControllerApi controller="slider" lang="en" />

--- a/docs-nextra/content/en/component/switch.mdx
+++ b/docs-nextra/content/en/component/switch.mdx
@@ -1,0 +1,61 @@
+---
+title: Switch
+description: Toggle immediate audio settings with Echo UI Switch.
+---
+
+import { ControllerApi } from '@/app/_components/controller-api'
+import { ControllerDemo } from '@/app/_components/controller-demo'
+import { InstallPackage } from '@/app/_components/install-package'
+
+# Switch
+
+Use `Switch` for settings that take effect immediately, such as bypass, monitoring, or synchronization.
+
+<InstallPackage lang="en" />
+
+```tsx
+import '@nafr/echo-ui/style.css'
+import { Switch } from '@nafr/echo-ui'
+
+export function MonitoringSwitch() {
+  return <Switch>Input monitoring</Switch>
+}
+```
+
+## Live example
+
+This controlled example supplies switch semantics and handles Space and Enter in addition to pointer clicks.
+
+<ControllerDemo controller="switch" lang="en" />
+
+## State behavior
+
+`Switch` keeps an internal Boolean initialized from `toggled` and synchronizes when the prop changes. Its `onChange` effect runs on mount and after the internal state changes, so callback code should safely accept the initial value.
+
+```tsx
+const [bypassed, setBypassed] = useState(false)
+
+<Switch
+  role="switch"
+  tabIndex={0}
+  aria-checked={bypassed}
+  toggled={bypassed}
+  onChange={setBypassed}
+  onKeyDown={(event) => {
+    if (event.key === ' ' || event.key === 'Enter') {
+      event.preventDefault()
+      setBypassed((current) => !current)
+    }
+  }}
+>
+  Bypass effect
+</Switch>
+```
+
+## Accessibility
+
+The current base component renders a `<label>` containing styled `<span>` elements, not a native checkbox or button. Pointer clicks work, but switch role, checked state, focusability, and keyboard activation are not automatic. Add the attributes and handler shown above, or use a native checkbox as the accessible state owner when building a form.
+
+## API
+
+<ControllerApi controller="switch" lang="en" />

--- a/docs-nextra/content/zh/_meta.ts
+++ b/docs-nextra/content/zh/_meta.ts
@@ -19,6 +19,11 @@ const meta: MetaRecord = {
     title: '指南',
     type: 'page',
   },
+  component: {
+    href: '/zh/component/button/',
+    title: '控制器',
+    type: 'page',
+  },
   community: {
     items: {
       discussions: {

--- a/docs-nextra/content/zh/component/_meta.ts
+++ b/docs-nextra/content/zh/component/_meta.ts
@@ -1,0 +1,14 @@
+import type { MetaRecord } from 'nextra'
+
+const meta: MetaRecord = {
+  button: 'Button 按钮',
+  checkbox: 'Checkbox 复选框',
+  envelope: 'Envelope 包络',
+  input: 'Input 输入框',
+  knob: 'Knob 旋钮',
+  radio: 'Radio 单选框',
+  slider: 'Slider 滑动条',
+  switch: 'Switch 开关',
+}
+
+export default meta

--- a/docs-nextra/content/zh/component/button.mdx
+++ b/docs-nextra/content/zh/component/button.mdx
@@ -1,0 +1,52 @@
+---
+title: Button 按钮
+description: 使用 Echo UI Button 构建可按下及分组的音频控件。
+---
+
+import { ControllerApi } from '@/app/_components/controller-api'
+import { ControllerDemo } from '@/app/_components/controller-demo'
+import { InstallPackage } from '@/app/_components/install-package'
+
+# Button 按钮
+
+`Button` 适用于瞬时操作、带按下状态的控件，以及紧凑的单选或多选按钮组。
+
+<InstallPackage lang="zh" />
+
+```tsx
+import '@nafr/echo-ui/style.css'
+import { Button } from '@nafr/echo-ui'
+
+export function AuditionButton() {
+  return <Button onClick={() => audition()}>试听音色</Button>
+}
+```
+
+## 实时示例
+
+第一个按钮把 `toggled` 保存在 React 状态中。下方分组是受控单选字段：点击波形后，父组件把新的 `value` 写回。
+
+<ControllerDemo controller="button" lang="zh" />
+
+## 状态与分组
+
+独立 `Button` 被点击时不会自行反转 `toggled`。应把 `toggled` 作为视觉状态，并在 `onClick` 或其他应用事件中更新它。`onToggleChange` 在渲染后观察有效状态，它并不是点击事件。
+
+`Button.Group` 会比较子按钮的 `value` 与分组 `value`。传入单个值表示单选，传入数组表示多选。两种模式都是受控的，因此需要保存 `onChange` 返回的值。
+
+```tsx
+const [waveform, setWaveform] = useState('sine')
+
+<Button.Group value={waveform} onChange={setWaveform} role="group" aria-label="波形">
+  <Button value="sine">正弦波</Button>
+  <Button value="square">方波</Button>
+</Button.Group>
+```
+
+## 无障碍
+
+`Button` 渲染原生 `<button>`，因此可以获得焦点，并可用 Enter 或空格激活。请通过子内容或 `aria-label` 提供可访问名称。切换按钮应让 `aria-pressed` 与 `toggled` 保持同步。`Button.Group` 是布局 `<div>`；当成员共同组成一个命名控件时，请添加 `role="group"` 和标签。
+
+## API
+
+<ControllerApi controller="button" lang="zh" />

--- a/docs-nextra/content/zh/component/checkbox.mdx
+++ b/docs-nextra/content/zh/component/checkbox.mdx
@@ -1,0 +1,52 @@
+---
+title: Checkbox 复选框
+description: 使用 Echo UI Checkbox 和 Checkbox.Group 选择多个音频选项。
+---
+
+import { ControllerApi } from '@/app/_components/controller-api'
+import { ControllerDemo } from '@/app/_components/controller-demo'
+import { InstallPackage } from '@/app/_components/install-package'
+
+# Checkbox 复选框
+
+独立布尔选项可使用 `Checkbox`；多个效果器、通道或能力可以同时启用时，可使用 `Checkbox.Group`。
+
+<InstallPackage lang="zh" />
+
+```tsx
+import '@nafr/echo-ui/style.css'
+import { Checkbox } from '@nafr/echo-ui'
+
+export function NormalizeOption() {
+  return <Checkbox>标准化输出</Checkbox>
+}
+```
+
+## 实时示例
+
+这个受控分组把 `event.value` 中的数组写回 `value`。
+
+<ControllerDemo controller="checkbox" lang="zh" />
+
+## 受控与独立使用
+
+不在分组中时，组件会保存一份由 `checked` 初始化的本地状态；外部 `checked` 改变时也会同步。`onChange` 接收 `{ value, nativeEvent }`，其中 `value` 是下一布尔值。
+
+位于 `Checkbox.Group` 内时，每个子项回传自己的 `value`，分组则回传下一值数组。请在父组件中保存该数组，以获得可靠的分组状态。
+
+```tsx
+const [effects, setEffects] = useState(['delay'])
+
+<Checkbox.Group value={effects} onChange={(event) => setEffects(event.value)} role="group">
+  <Checkbox value="delay">延迟</Checkbox>
+  <Checkbox value="reverb">混响</Checkbox>
+</Checkbox.Group>
+```
+
+## 无障碍
+
+每个复选框都包含原生 `input[type="checkbox"]`，子内容会成为可见标签，因此具备焦点、空格激活和选中语义。当集合需要共享名称时，为分组包装器添加 `role="group"` 以及 `aria-label` 或 `aria-labelledby`。当前公开类型是 `React.HTMLAttributes<HTMLInputElement>`，所以 `name` 等输入框专属属性没有暴露。
+
+## API
+
+<ControllerApi controller="checkbox" lang="zh" />

--- a/docs-nextra/content/zh/component/envelope.mdx
+++ b/docs-nextra/content/zh/component/envelope.mdx
@@ -1,0 +1,59 @@
+---
+title: Envelope 包络
+description: 使用 Echo UI Envelope 编辑 ADSR、AHDSR 和 DADSR 曲线。
+---
+
+import { ControllerApi } from '@/app/_components/controller-api'
+import { ControllerDemo } from '@/app/_components/controller-demo'
+import { InstallPackage } from '@/app/_components/install-package'
+
+# Envelope 包络
+
+`Envelope` 用于可视化振幅包络，并允许通过指针编辑各阶段。默认使用 ADSR 数据；加入 `hold` 可表示 AHDSR，同时加入 `delay` 与 `hold` 可表示 DADSR。
+
+<InstallPackage lang="zh" />
+
+```tsx
+import '@nafr/echo-ui/style.css'
+import { Envelope, type EnvelopeData } from '@nafr/echo-ui'
+
+const initial: EnvelopeData = {
+  attack: 0.1,
+  decay: 0.3,
+  sustain: 0.65,
+  release: 0.5,
+}
+```
+
+## 实时示例
+
+拖动 SVG 节点，或编辑等价的原生字段。两种操作都会更新同一个受控 `data` 对象。
+
+<ControllerDemo controller="envelope" lang="zh" />
+
+## 数据与上限
+
+`data` 为必填。时间阶段可使用秒或任意一致的时长单位；`sustain` 归一化到 `0` 至 `1`。`limits` 设置各时间阶段可拖动的最大时长。若 `data` 未包含 `delay` 或 `hold`，该阶段会被移除，对应上限也会变为零。
+
+```tsx
+const [data, setData] = useState(initial)
+
+<div style={{ width: 480, height: 220 }}>
+  <Envelope
+    data={data}
+    limits={{ attack: 2, decay: 2, release: 4 }}
+    onChange={setData}
+    onChangeEnd={(finalData) => saveEnvelope(finalData)}
+  />
+</div>
+```
+
+请为父容器设置明确尺寸：组件会填满容器。节点移动时调用 `onChange`，拖动结束后调用 `onChangeEnd`。
+
+## 无障碍
+
+包络图是 SVG 指针编辑器，目前没有可键盘操作的控件语义。应把它作为可视化，并为相同阶段值提供带标签的原生输入，如实时示例所示。当原生字段作为无障碍编辑表面时，可将图形设置为 `aria-hidden`，重要的保存状态变化应单独播报。
+
+## API
+
+<ControllerApi controller="envelope" lang="zh" />

--- a/docs-nextra/content/zh/component/input.mdx
+++ b/docs-nextra/content/zh/component/input.mdx
@@ -1,0 +1,57 @@
+---
+title: Input 输入框
+description: 使用 Echo UI Input 输入或拖动音频参数值。
+---
+
+import { ControllerApi } from '@/app/_components/controller-api'
+import { ControllerDemo } from '@/app/_components/controller-demo'
+import { InstallPackage } from '@/app/_components/install-package'
+
+# Input 输入框
+
+`Input` 支持普通文本输入和有边界的数字输入。数字输入还支持垂直指针拖动，并用进度填充显示当前所在位置。
+
+<InstallPackage lang="zh" />
+
+```tsx
+import '@nafr/echo-ui/style.css'
+import { Input } from '@nafr/echo-ui'
+
+export function TrackName() {
+  return <Input type="text" aria-label="轨道名称" value="主音合成器" />
+}
+```
+
+## 实时示例
+
+可直接输入增益值，也可在移动超过 20 像素后垂直拖动。此处 `-60` 至 `12` 的双向填充会从区间中点（`-24`）向两侧延伸。
+
+<ControllerDemo controller="input" lang="zh" />
+
+## 数值行为
+
+组件保存本地状态，默认值为 `0`，并在 `value` 改变时同步。应用状态应传入 `value`，并保存 `onChange` 的 `event.value`。数字值会限制在 `min` 和 `max` 之间；拖动按 `step` 吸附，并由 `sensitivity` 缩放。
+
+```tsx
+const [gain, setGain] = useState(-6)
+
+<Input
+  aria-label="增益（分贝）"
+  bilateral
+  min={-60}
+  max={12}
+  step={0.5}
+  value={gain}
+  onChange={(event) => setGain(Number(event.value))}
+/>
+```
+
+当正常文本选择或触摸行为比拖动编辑更重要时，可设置 `prohibitDrag`。`hideProgress` 只会移除填充，不会改变数值行为。
+
+## 无障碍
+
+`Input` 渲染原生 `<input>`，请使用 `<label>`、`aria-label` 或 `aria-labelledby` 进行标准标注。数字输入保留浏览器键盘行为。指针拖动只是增强方式，不应成为唯一的编辑手段。请在标签中显示单位，而不要只依靠进度颜色传达数值。
+
+## API
+
+<ControllerApi controller="input" lang="zh" />

--- a/docs-nextra/content/zh/component/knob.mdx
+++ b/docs-nextra/content/zh/component/knob.mdx
@@ -1,0 +1,50 @@
+---
+title: Knob 旋钮
+description: 使用 Echo UI Knob 构建旋转式音频控件和参数组。
+---
+
+import { ControllerApi } from '@/app/_components/controller-api'
+import { ControllerDemo } from '@/app/_components/controller-demo'
+import { InstallPackage } from '@/app/_components/install-package'
+
+# Knob 旋钮
+
+`Knob` 把垂直指针移动映射为旋转显示。`Knob.Group` 可在一组旋钮间共享范围、灵敏度、尺寸与颜色，而每个子项保留自己的数值回调。
+
+<InstallPackage lang="zh" />
+
+```tsx
+import '@nafr/echo-ui/style.css'
+import { Knob } from '@nafr/echo-ui'
+
+export function GainKnob() {
+  return <Knob min={-60} max={12} value={-6} topLabel="增益" bottomLabel="-6 dB" />
+}
+```
+
+## 实时示例
+
+在任一旋钮上向上或向下拖动。下方原生范围输入镜像“增益”，因此键盘和辅助技术用户也能编辑同一状态。
+
+<ControllerDemo controller="knob" lang="zh" />
+
+## 数值与分组
+
+数值默认是 `0`，会限制在 `min` 与 `max` 之间，并在拖动时按 `step` 吸附。`rotationRange` 限制在 90 至 360 度。`bilateral` 从中点绘制进度，适合声像和双极调制。
+
+```tsx
+<Knob.Group size="5rem" min={-50} max={50} bilateral>
+  <Knob value={panA} onChange={setPanA} topLabel="通道 A" />
+  <Knob value={panB} onChange={setPanB} topLabel="通道 B" />
+</Knob.Group>
+```
+
+分组属性只是默认值：子项显式属性优先。`value`、`onChange`、`onChangeEnd`、`topLabel` 与 `bottomLabel` 仍属于各旋钮。
+
+## 无障碍
+
+视觉触发器带有 `role="slider"`，但当前组件没有在该触发器上提供可访问名称、ARIA 数值、焦点或键盘处理。请勿把它用作无障碍表单中的唯一数值编辑器。应像上方示例一样，绑定同一状态并配套带标签的原生范围或数字输入。
+
+## API
+
+<ControllerApi controller="knob" lang="zh" />

--- a/docs-nextra/content/zh/component/radio.mdx
+++ b/docs-nextra/content/zh/component/radio.mdx
@@ -1,0 +1,56 @@
+---
+title: Radio 单选框
+description: 使用 Echo UI Radio 和 Radio.Group 选择一个音频选项。
+---
+
+import { ControllerApi } from '@/app/_components/controller-api'
+import { ControllerDemo } from '@/app/_components/controller-demo'
+import { InstallPackage } from '@/app/_components/install-package'
+
+# Radio 单选框
+
+当且仅当一个选项可处于激活状态时，可使用 `Radio.Group`，例如渲染质量、振荡器模式或监听源。
+
+<InstallPackage lang="zh" />
+
+```tsx
+import '@nafr/echo-ui/style.css'
+import { Radio } from '@nafr/echo-ui'
+
+export function QualityChoice() {
+  return <Radio checked>均衡</Radio>
+}
+```
+
+## 实时示例
+
+分组把选中项保存在 React 状态中，并通过 `event.value` 返回下一选项。
+
+<ControllerDemo controller="radio" lang="zh" />
+
+## 受控分组
+
+独立单选框由 `checked` 初始化，并可在后续 `checked` 属性改变时同步。`Radio.Group` 是受控的：它比较分组 `value` 与各子项 `value`，因此需要从 `onChange` 更新分组值。
+
+```tsx
+const [quality, setQuality] = useState('balanced')
+
+<Radio.Group
+  role="radiogroup"
+  aria-label="渲染质量"
+  value={quality}
+  onChange={(event) => setQuality(event.value)}
+>
+  <Radio value="draft">草稿</Radio>
+  <Radio value="balanced">均衡</Radio>
+  <Radio value="studio">录音室</Radio>
+</Radio.Group>
+```
+
+## 无障碍
+
+每个选项包含原生 `input[type="radio"]`，因此可以获得焦点并使用空格激活。分组包装器只是普通 `<div>`；请添加 `role="radiogroup"` 和可访问名称。`RadioProps` 当前没有暴露原生 `name` 属性，所以无法通过公开类型建立浏览器原生命名单选组；在需要方向键分组导航的表单中，应明确记录这一限制。
+
+## API
+
+<ControllerApi controller="radio" lang="zh" />

--- a/docs-nextra/content/zh/component/slider.mdx
+++ b/docs-nextra/content/zh/component/slider.mdx
@@ -1,0 +1,57 @@
+---
+title: Slider 滑动条
+description: 使用 Echo UI Slider 显示和编辑连续音频数值。
+---
+
+import { ControllerApi } from '@/app/_components/controller-api'
+import { ControllerDemo } from '@/app/_components/controller-demo'
+import { InstallPackage } from '@/app/_components/install-package'
+
+# Slider 滑动条
+
+`Slider` 把指针位置转换成有边界的数字值。它支持水平或垂直轨道、双极进度、可选坐标轴以及只读展示模式。
+
+<InstallPackage lang="zh" />
+
+```tsx
+import '@nafr/echo-ui/style.css'
+import { Slider } from '@nafr/echo-ui'
+
+export function MixSlider() {
+  return <Slider min={0} max={100} value={35} />
+}
+```
+
+## 实时示例
+
+可拖动轨道，也可聚焦后使用方向键。示例在指针驱动的基础组件之外，补充了所需的 ARIA 与键盘行为。
+
+<ControllerDemo controller="slider" lang="zh" />
+
+## 数值行为
+
+数值默认是 `0`，会限制在 `min` 和 `max` 之间，并按 `step` 吸附。拖动时组件更新本地状态，`value` 改变时会同步。应用状态应保存 `onChange`；提交自动化等只需执行一次的工作可放在 `onChangeEnd`。
+
+`bilateral` 从中点绘制进度。`prohibitInteraction` 保留普通颜色，用作只读显示；`disabled` 同样阻止交互，但会使用禁用样式。`axis` 会渲染 Echo UI `Axis`，可通过 `axisProps` 配置。
+
+```tsx
+<Slider
+  role="slider"
+  tabIndex={0}
+  aria-label="干湿比"
+  aria-valuemin={0}
+  aria-valuemax={100}
+  aria-valuenow={mix}
+  value={mix}
+  onChange={setMix}
+  onKeyDown={handleArrowKeys}
+/>
+```
+
+## 无障碍
+
+基础组件渲染由指针操作的 `<div>`，没有滑动条语义或键盘行为。当它是唯一编辑器时，请添加 `role="slider"`、焦点目标、可访问名称、当前/最小/最大 ARIA 数值，以及方向键处理。也可以为可视化配套原生 `input[type="range"]`。不要只依靠进度颜色传达数值。
+
+## API
+
+<ControllerApi controller="slider" lang="zh" />

--- a/docs-nextra/content/zh/component/switch.mdx
+++ b/docs-nextra/content/zh/component/switch.mdx
@@ -1,0 +1,61 @@
+---
+title: Switch 开关
+description: 使用 Echo UI Switch 切换立即生效的音频设置。
+---
+
+import { ControllerApi } from '@/app/_components/controller-api'
+import { ControllerDemo } from '@/app/_components/controller-demo'
+import { InstallPackage } from '@/app/_components/install-package'
+
+# Switch 开关
+
+`Switch` 适合切换立即生效的设置，例如旁通、监听或同步。
+
+<InstallPackage lang="zh" />
+
+```tsx
+import '@nafr/echo-ui/style.css'
+import { Switch } from '@nafr/echo-ui'
+
+export function MonitoringSwitch() {
+  return <Switch>输入监听</Switch>
+}
+```
+
+## 实时示例
+
+这个受控示例提供开关语义，并在指针点击之外处理空格和 Enter。
+
+<ControllerDemo controller="switch" lang="zh" />
+
+## 状态行为
+
+`Switch` 保存一份由 `toggled` 初始化的内部布尔值，并在属性变化时同步。它的 `onChange` effect 会在挂载时以及内部状态变化后运行，因此回调代码应能安全接收初始值。
+
+```tsx
+const [bypassed, setBypassed] = useState(false)
+
+<Switch
+  role="switch"
+  tabIndex={0}
+  aria-checked={bypassed}
+  toggled={bypassed}
+  onChange={setBypassed}
+  onKeyDown={(event) => {
+    if (event.key === ' ' || event.key === 'Enter') {
+      event.preventDefault()
+      setBypassed((current) => !current)
+    }
+  }}
+>
+  旁通效果器
+</Switch>
+```
+
+## 无障碍
+
+当前基础组件渲染包含样式化 `<span>` 的 `<label>`，而不是原生复选框或按钮。指针点击可用，但不会自动提供开关 role、选中状态、焦点和键盘激活。请添加上方所示属性与处理函数；构建表单时也可以使用原生复选框作为可访问状态来源。
+
+## API
+
+<ControllerApi controller="switch" lang="zh" />

--- a/package.json
+++ b/package.json
@@ -61,12 +61,13 @@
     "dev:docs:nextra": "pnpm --filter @nafr/echo-ui-docs-nextra dev",
     "build:docs:nextra": "pnpm --filter @nafr/echo-ui-docs-nextra build",
     "typecheck:docs:nextra": "pnpm --filter @nafr/echo-ui-docs-nextra typecheck",
-    "test:docs:nextra": "node scripts/verify-nextra-output.mjs",
+    "test:docs:nextra": "node scripts/verify-nextra-output.mjs && node scripts/smoke-nextra-routes.mjs",
     "verify": "pnpm typecheck && pnpm typecheck:example && pnpm typecheck:docs:nextra && pnpm test && pnpm build:example && pnpm build:docs:nextra && pnpm test:docs:nextra && pnpm build:docs"
   },
   "devDependencies": {
     "@nextui-org/react": "^2.2.9",
     "@nextui-org/theme": "2.4.5",
+    "@playwright/test": "1.51.1",
     "@testing-library/dom": "^10.4.1",
     "@testing-library/react": "^16.3.2",
     "@types/d3": "^7.4.3",

--- a/packages/components/controller/Button/Button.tsx
+++ b/packages/components/controller/Button/Button.tsx
@@ -43,7 +43,7 @@ export const Button = forwardRef<ButtonRef, ButtonProps>((props, ref) => {
 
       // If the button is in a group and have the specifical value,
       // we need to handle the toggling
-      if (!isInGroup || !value) return
+      if (!isInGroup || value === undefined) return
       groupContext.onChange?.(value)
     },
     [disabled, isInGroup, groupContext, value, onClick],

--- a/packages/components/controller/Button/Group.tsx
+++ b/packages/components/controller/Button/Group.tsx
@@ -44,7 +44,7 @@ export const ButtonGroup = forwardRef<ButtonGroupRef, ButtonGroupProps>((props, 
 
   return (
     <ButtonGroupContextProvider value={contextValue}>
-      <div ref={ref} className={cn(useGroupStyle(), className)} style={style}>
+      <div {...restProps} ref={ref} className={cn(useGroupStyle(), className)} style={style}>
         {restProps.children}
       </div>
     </ButtonGroupContextProvider>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,6 +30,9 @@ importers:
       '@nextui-org/theme':
         specifier: 2.4.5
         version: 2.4.5(tailwindcss@3.4.19(yaml@2.9.0))
+      '@playwright/test':
+        specifier: 1.51.1
+        version: 1.51.1
       '@testing-library/dom':
         specifier: ^10.4.1
         version: 10.4.1
@@ -50,7 +53,7 @@ importers:
         version: 18.3.7(@types/react@18.3.31)
       '@vercel/analytics':
         specifier: ^1.1.2
-        version: 1.6.1(next@16.2.10(@babel/core@7.29.7)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(sass@1.54.5))(react@18.2.0)
+        version: 1.6.1(next@16.2.10(@babel/core@7.18.6)(@playwright/test@1.51.1)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(sass@1.54.5))(react@18.2.0)
       '@vitejs/plugin-react':
         specifier: ^6.0.3
         version: 6.0.3(vite@8.1.5(@types/node@20.19.43)(jiti@1.21.7)(sass@1.54.5)(yaml@2.9.0))
@@ -125,13 +128,13 @@ importers:
         version: link:..
       next:
         specifier: 16.2.10
-        version: 16.2.10(@babel/core@7.29.7)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(sass@1.54.5)
+        version: 16.2.10(@babel/core@7.18.6)(@playwright/test@1.51.1)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(sass@1.54.5)
       nextra:
         specifier: 4.6.0
-        version: 4.6.0(next@16.2.10(@babel/core@7.29.7)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(sass@1.54.5))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@6.0.3)
+        version: 4.6.0(next@16.2.10(@babel/core@7.18.6)(@playwright/test@1.51.1)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(sass@1.54.5))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@6.0.3)
       nextra-theme-docs:
         specifier: 4.6.0
-        version: 4.6.0(@types/react@18.3.31)(next@16.2.10(@babel/core@7.29.7)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(sass@1.54.5))(nextra@4.6.0(next@16.2.10(@babel/core@7.29.7)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(sass@1.54.5))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@6.0.3))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(use-sync-external-store@1.6.0(react@18.2.0))
+        version: 4.6.0(@types/react@18.3.31)(next@16.2.10(@babel/core@7.18.6)(@playwright/test@1.51.1)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(sass@1.54.5))(nextra@4.6.0(next@16.2.10(@babel/core@7.18.6)(@playwright/test@1.51.1)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(sass@1.54.5))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@6.0.3))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(use-sync-external-store@1.6.0(react@18.2.0))
       react:
         specifier: 18.2.0
         version: 18.2.0
@@ -1507,6 +1510,11 @@ packages:
 
   '@oxc-project/types@0.139.0':
     resolution: {integrity: sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==}
+
+  '@playwright/test@1.51.1':
+    resolution: {integrity: sha512-nM+kEaTSAoVlXmMPH10017vn3FSiFqr/bh4fKg9vmAdMfd9SDqRZNvPSiAHADc/itWak+qPvMPZQOPwCBW7k7Q==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   '@polka/url@0.5.0':
     resolution: {integrity: sha512-oZLYFEAzUKyi3SKnXvj32ZCEGH6RDnao7COuCVhDydMS9NrCSVXhM79VaKyP5+Zc33m0QXEd2DN3UkU7OsHcfw==}
@@ -4057,6 +4065,11 @@ packages:
     resolution: {integrity: sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==}
     engines: {node: '>=12'}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -5230,6 +5243,16 @@ packages:
 
   pkg-types@2.3.1:
     resolution: {integrity: sha512-y+ichcgc2LrADuhLNAx8DFjVfgz91pRxfZdI3UDhxHvcVEZsenLO+7XaU5vOp0u/7V/wZ+plyuQxtrDlZJ+yeg==}
+
+  playwright-core@1.51.1:
+    resolution: {integrity: sha512-/crRMj8+j/Nq5s8QcvegseuyeZPxpQCZb6HNk3Sos3BlZyAknRjoyJPFWkpNn8v0+P3WiwqFF8P+zQo4eqiNuw==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.51.1:
+    resolution: {integrity: sha512-kkx+MB2KQRkyxjYPc3a0wLZZoDczmppyGJIvQ43l+aZihkaVvmu/21kiyaHeHjiFxjxNNFnUncKmcGIyOojsaw==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   points-on-curve@0.2.0:
     resolution: {integrity: sha512-0mYKnYYe9ZcqMCWhUjItv/oHjvgEsfKvnUTg8sAtnHr3GVy7rGkXCb6d5cSyqrWqL4k81b9CPg3urd+T7aop3A==}
@@ -8157,6 +8180,10 @@ snapshots:
 
   '@oxc-project/types@0.139.0': {}
 
+  '@playwright/test@1.51.1':
+    dependencies:
+      playwright: 1.51.1
+
   '@polka/url@0.5.0': {}
 
   '@polka/url@1.0.0-next.29': {}
@@ -10061,9 +10088,9 @@ snapshots:
       d3-selection: 3.0.0
       d3-transition: 3.0.1(d3-selection@3.0.0)
 
-  '@vercel/analytics@1.6.1(next@16.2.10(@babel/core@7.29.7)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(sass@1.54.5))(react@18.2.0)':
+  '@vercel/analytics@1.6.1(next@16.2.10(@babel/core@7.18.6)(@playwright/test@1.51.1)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(sass@1.54.5))(react@18.2.0)':
     optionalDependencies:
-      next: 16.2.10(@babel/core@7.29.7)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(sass@1.54.5)
+      next: 16.2.10(@babel/core@7.18.6)(@playwright/test@1.51.1)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(sass@1.54.5)
       react: 18.2.0
 
   '@vitejs/plugin-react@2.0.1(vite@3.1.8(sass@1.54.5))':
@@ -11107,6 +11134,9 @@ snapshots:
       graceful-fs: 4.2.11
       jsonfile: 6.2.1
       universalify: 2.0.1
+
+  fsevents@2.3.2:
+    optional: true
 
   fsevents@2.3.3:
     optional: true
@@ -12779,7 +12809,7 @@ snapshots:
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
 
-  next@16.2.10(@babel/core@7.29.7)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(sass@1.54.5):
+  next@16.2.10(@babel/core@7.18.6)(@playwright/test@1.51.1)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(sass@1.54.5):
     dependencies:
       '@next/env': 16.2.10
       '@swc/helpers': 0.5.15
@@ -12788,7 +12818,7 @@ snapshots:
       postcss: 8.4.31
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-      styled-jsx: 5.1.6(@babel/core@7.29.7)(react@18.2.0)
+      styled-jsx: 5.1.6(@babel/core@7.18.6)(react@18.2.0)
     optionalDependencies:
       '@next/swc-darwin-arm64': 16.2.10
       '@next/swc-darwin-x64': 16.2.10
@@ -12798,19 +12828,20 @@ snapshots:
       '@next/swc-linux-x64-musl': 16.2.10
       '@next/swc-win32-arm64-msvc': 16.2.10
       '@next/swc-win32-x64-msvc': 16.2.10
+      '@playwright/test': 1.51.1
       sass: 1.54.5
       sharp: 0.34.5
     transitivePeerDependencies:
       - '@babel/core'
       - babel-plugin-macros
 
-  nextra-theme-docs@4.6.0(@types/react@18.3.31)(next@16.2.10(@babel/core@7.29.7)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(sass@1.54.5))(nextra@4.6.0(next@16.2.10(@babel/core@7.29.7)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(sass@1.54.5))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@6.0.3))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(use-sync-external-store@1.6.0(react@18.2.0)):
+  nextra-theme-docs@4.6.0(@types/react@18.3.31)(next@16.2.10(@babel/core@7.18.6)(@playwright/test@1.51.1)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(sass@1.54.5))(nextra@4.6.0(next@16.2.10(@babel/core@7.18.6)(@playwright/test@1.51.1)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(sass@1.54.5))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@6.0.3))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(use-sync-external-store@1.6.0(react@18.2.0)):
     dependencies:
       '@headlessui/react': 2.2.10(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       clsx: 2.1.1
-      next: 16.2.10(@babel/core@7.29.7)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(sass@1.54.5)
+      next: 16.2.10(@babel/core@7.18.6)(@playwright/test@1.51.1)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(sass@1.54.5)
       next-themes: 0.4.6(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
-      nextra: 4.6.0(next@16.2.10(@babel/core@7.29.7)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(sass@1.54.5))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@6.0.3)
+      nextra: 4.6.0(next@16.2.10(@babel/core@7.18.6)(@playwright/test@1.51.1)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(sass@1.54.5))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@6.0.3)
       react: 18.2.0
       react-compiler-runtime: 19.1.0-rc.3(react@18.2.0)
       react-dom: 18.2.0(react@18.2.0)
@@ -12822,7 +12853,7 @@ snapshots:
       - immer
       - use-sync-external-store
 
-  nextra@4.6.0(next@16.2.10(@babel/core@7.29.7)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(sass@1.54.5))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@6.0.3):
+  nextra@4.6.0(next@16.2.10(@babel/core@7.18.6)(@playwright/test@1.51.1)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(sass@1.54.5))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@6.0.3):
     dependencies:
       '@formatjs/intl-localematcher': 0.6.2
       '@headlessui/react': 2.2.10(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
@@ -12843,7 +12874,7 @@ snapshots:
       mdast-util-gfm: 3.1.0
       mdast-util-to-hast: 13.2.1
       negotiator: 1.0.0
-      next: 16.2.10(@babel/core@7.29.7)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(sass@1.54.5)
+      next: 16.2.10(@babel/core@7.18.6)(@playwright/test@1.51.1)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(sass@1.54.5)
       react: 18.2.0
       react-compiler-runtime: 19.1.0-rc.3(react@18.2.0)
       react-dom: 18.2.0(react@18.2.0)
@@ -13039,6 +13070,14 @@ snapshots:
       confbox: 0.2.4
       exsolve: 1.1.0
       pathe: 2.0.3
+
+  playwright-core@1.51.1: {}
+
+  playwright@1.51.1:
+    dependencies:
+      playwright-core: 1.51.1
+    optionalDependencies:
+      fsevents: 2.3.2
 
   points-on-curve@0.2.0: {}
 
@@ -13792,12 +13831,12 @@ snapshots:
     dependencies:
       inline-style-parser: 0.2.7
 
-  styled-jsx@5.1.6(@babel/core@7.29.7)(react@18.2.0):
+  styled-jsx@5.1.6(@babel/core@7.18.6)(react@18.2.0):
     dependencies:
       client-only: 0.0.1
       react: 18.2.0
     optionalDependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.18.6
 
   stylis@4.4.0: {}
 

--- a/scripts/smoke-nextra-routes.mjs
+++ b/scripts/smoke-nextra-routes.mjs
@@ -1,0 +1,178 @@
+import assert from 'node:assert/strict'
+import { createReadStream } from 'node:fs'
+import { stat } from 'node:fs/promises'
+import { createServer } from 'node:http'
+import { dirname, extname, resolve, sep } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { chromium } from '@playwright/test'
+
+const repositoryRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..')
+const outputRoot = resolve(repositoryRoot, 'docs-nextra', 'out')
+const basePath = process.env.DOCS_BASE_PATH ?? ''
+const controllers = ['button', 'checkbox', 'envelope', 'input', 'knob', 'radio', 'slider', 'switch']
+const locales = ['en', 'zh']
+
+assert.ok(!basePath || (basePath.startsWith('/') && !basePath.endsWith('/')))
+
+const contentTypes = {
+  '.css': 'text/css; charset=utf-8',
+  '.html': 'text/html; charset=utf-8',
+  '.js': 'text/javascript; charset=utf-8',
+  '.json': 'application/json; charset=utf-8',
+  '.svg': 'image/svg+xml',
+  '.woff2': 'font/woff2',
+}
+
+const fileForRequest = (requestUrl) => {
+  const pathname = decodeURIComponent(new URL(requestUrl, 'http://localhost').pathname)
+  const hasExpectedBasePath =
+    !basePath || pathname === basePath || pathname.startsWith(`${basePath}/`)
+  assert.ok(hasExpectedBasePath, `${pathname} should stay within the configured base path`)
+  const relativePath = basePath ? pathname.slice(basePath.length) : pathname
+  const normalizedPath = relativePath.replace(/^\/+/, '')
+  const requestedPath = resolve(
+    outputRoot,
+    normalizedPath && !normalizedPath.endsWith('/')
+      ? normalizedPath
+      : normalizedPath + 'index.html',
+  )
+
+  assert.ok(
+    requestedPath === outputRoot || requestedPath.startsWith(`${outputRoot}${sep}`),
+    'Browser smoke request must stay within the static output directory.',
+  )
+
+  return requestedPath
+}
+
+const server = createServer(async (request, response) => {
+  try {
+    let filePath = fileForRequest(request.url ?? '/')
+    const fileStats = await stat(filePath)
+    if (fileStats.isDirectory()) filePath = resolve(filePath, 'index.html')
+
+    response.writeHead(200, {
+      'Content-Type': contentTypes[extname(filePath)] ?? 'application/octet-stream',
+    })
+    createReadStream(filePath).pipe(response)
+  } catch {
+    response.writeHead(404)
+    response.end('Not found')
+  }
+})
+
+const listen = () =>
+  new Promise((resolveListen, reject) => {
+    server.once('error', reject)
+    server.listen(0, '127.0.0.1', () => resolveListen(server.address()))
+  })
+
+const closeServer = () => new Promise((resolveClose) => server.close(resolveClose))
+
+const launchBrowser = async () => {
+  const channel = process.env.PLAYWRIGHT_CHANNEL
+  if (channel) return chromium.launch({ channel, headless: true })
+
+  try {
+    return await chromium.launch({ headless: true })
+  } catch (bundledBrowserError) {
+    try {
+      return await chromium.launch({ channel: 'chrome', headless: true })
+    } catch {
+      throw new Error(
+        'Playwright could not launch Chromium or Chrome. Run `pnpm exec playwright install chromium` or set PLAYWRIGHT_CHANNEL.',
+        { cause: bundledBrowserError },
+      )
+    }
+  }
+}
+
+const waitForStatus = (page, controller, expectedText) =>
+  page.waitForFunction(
+    ({ controllerName, text }) =>
+      document
+        .querySelector(`[data-controller-demo="${controllerName}"] [aria-live="polite"]`)
+        ?.textContent?.includes(text),
+    { controllerName: controller, text: expectedText },
+  )
+
+const exerciseDemo = async (page, controller, locale) => {
+  const demo = page.locator(`[data-controller-demo="${controller}"]`)
+
+  switch (controller) {
+    case 'button':
+      await demo.getByRole('button', { name: 'Square' }).click()
+      await waitForStatus(page, controller, 'square')
+      break
+    case 'checkbox':
+      await demo.getByRole('checkbox', { name: 'Chorus' }).check()
+      await waitForStatus(page, controller, 'chorus')
+      break
+    case 'envelope':
+      await demo.getByRole('spinbutton', { name: 'attack' }).fill('0.2')
+      await waitForStatus(page, controller, 'A 0.20')
+      break
+    case 'input':
+      await demo.getByLabel(locale === 'zh' ? '增益' : 'Gain').fill('4.5')
+      await waitForStatus(page, controller, '4.5 dB')
+      break
+    case 'knob':
+      await demo
+        .getByRole('slider', { name: locale === 'zh' ? '增益镜像输入' : 'Gain mirror input' })
+        .press('ArrowRight')
+      await waitForStatus(page, controller, '-2 dB')
+      break
+    case 'radio':
+      await demo.getByRole('radio', { name: locale === 'zh' ? '草稿' : 'Draft' }).check()
+      await waitForStatus(page, controller, 'draft')
+      break
+    case 'slider':
+      await demo
+        .getByRole('slider', { name: locale === 'zh' ? '干湿比' : 'Wet mix' })
+        .press('ArrowRight')
+      await waitForStatus(page, controller, '40%')
+      break
+    case 'switch':
+      await demo.getByRole('switch').press('Space')
+      await demo.getByRole('switch').waitFor({ state: 'visible' })
+      assert.equal(await demo.getByRole('switch').getAttribute('aria-checked'), 'true')
+      break
+  }
+}
+
+const address = await listen()
+assert.ok(address && typeof address === 'object')
+
+const origin = `http://127.0.0.1:${address.port}`
+let browser
+
+try {
+  browser = await launchBrowser()
+
+  for (const locale of locales) {
+    for (const controller of controllers) {
+      const route = `${basePath}/${locale}/component/${controller}/`
+      const page = await browser.newPage()
+      const browserErrors = []
+
+      page.on('pageerror', (error) => browserErrors.push(error.message))
+      page.on('console', (message) => {
+        if (message.type() === 'error') browserErrors.push(message.text())
+      })
+
+      const response = await page.goto(`${origin}${route}`, { waitUntil: 'networkidle' })
+      assert.ok(response?.ok(), `${route} should return a successful browser response`)
+      await page.locator(`[data-controller-demo="${controller}"]`).waitFor({ state: 'visible' })
+      await page.locator(`[data-controller-api="${controller}"]`).waitFor({ state: 'visible' })
+      await exerciseDemo(page, controller, locale)
+      assert.deepEqual(browserErrors, [], `${route} should hydrate without browser errors`)
+
+      await page.close()
+    }
+  }
+} finally {
+  await browser?.close()
+  await closeServer()
+}
+
+console.log('Nextra browser smoke loaded and exercised all bilingual controller routes.')

--- a/scripts/verify-nextra-output.mjs
+++ b/scripts/verify-nextra-output.mjs
@@ -133,6 +133,7 @@ const pages = [
 const locales = {
   en: {
     counterpart: 'zh',
+    controllerLabel: 'Controllers',
     editLink: 'Edit this page on GitHub',
     footer: 'Released under the MIT License.',
     guideLabel: 'Guide',
@@ -140,12 +141,15 @@ const locales = {
   },
   zh: {
     counterpart: 'en',
+    controllerLabel: '控制器',
     editLink: '在 GitHub 上编辑此页',
     footer: '基于 MIT 许可证发布。',
     guideLabel: '指南',
     tocLabel: '本页目录',
   },
 }
+
+const controllers = ['button', 'checkbox', 'envelope', 'input', 'knob', 'radio', 'slider', 'switch']
 
 for (const page of pages) {
   for (const [locale, labels] of Object.entries(locales)) {
@@ -209,6 +213,71 @@ for (const locale of Object.keys(locales)) {
   assert.ok(!installationPage.includes('Tailwind CSS 3 或更高'))
 }
 
+for (const [locale, labels] of Object.entries(locales)) {
+  for (const controller of controllers) {
+    const html = await readFile(
+      resolve(outputRoot, locale, 'component', controller, 'index.html'),
+      'utf8',
+    )
+    const localizedRoute = `/${locale}/component/${controller}/`
+    const sourcePath = `content/${locale}/component/${controller}.mdx`
+
+    assert.match(html, new RegExp(`<html[^>]+lang="${locale}"`))
+    assert.ok(
+      html.includes(`data-controller-demo="${controller}"`),
+      `${localizedRoute} should render its interactive local-package demo`,
+    )
+    assert.ok(
+      html.includes(`data-controller-api="${controller}"`),
+      `${localizedRoute} should render its public API reference`,
+    )
+    assert.ok(
+      html.includes('pnpm add @nafr/echo-ui'),
+      `${localizedRoute} should include installation guidance`,
+    )
+    assert.ok(
+      html.includes(`href="${withBasePath(localizedRoute)}"`),
+      `${localizedRoute} navigation should expose the localized route`,
+    )
+    assert.ok(
+      html.includes(`href="${withBasePath(`/${locale}/component/button/`)}"`),
+      `${localizedRoute} should expose localized controller navigation`,
+    )
+    assert.ok(
+      html.includes(labels.controllerLabel),
+      `${localizedRoute} should label controller navigation`,
+    )
+    assert.ok(html.includes('title="Change theme"'), `${localizedRoute} should switch themes`)
+    assert.ok(html.includes('title="Change language"'), `${localizedRoute} should switch locales`)
+    assert.ok(
+      html.includes(labels.tocLabel),
+      `${localizedRoute} should label its table of contents`,
+    )
+    assert.ok(html.includes(labels.editLink), `${localizedRoute} should expose its edit link`)
+    assert.ok(html.includes(labels.footer), `${localizedRoute} should include a localized footer`)
+    assert.ok(
+      html.includes(`https://github.com/codeacme17/echo-ui/tree/main/docs-nextra/${sourcePath}`),
+      `${localizedRoute} should edit the matching source file`,
+    )
+    await access(resolve(outputRoot, labels.counterpart, 'component', controller, 'index.html'))
+    await assertInternalLinksResolve(html, localizedRoute)
+
+    for (const assetPath of html.matchAll(/(?:href|src)="([^"?]*\/_next\/[^"?]+)(?:\?[^"?]*)?"/g)) {
+      assert.ok(assetPath[1].startsWith(`${basePath}/_next/`))
+      await access(resolve(outputRoot, decodeURIComponent(assetPath[1].slice(basePath.length + 1))))
+    }
+  }
+}
+
+for (const sourceRoot of [resolve(nextraRoot, 'app'), resolve(nextraRoot, 'content')]) {
+  const sourceFiles = (await readdir(sourceRoot, { recursive: true }))
+    .filter((file) => /\.(?:mdx|ts|tsx)$/.test(file))
+    .map((file) => resolve(sourceRoot, file))
+  const source = (await Promise.all(sourceFiles.map((file) => readFile(file, 'utf8')))).join('\n')
+
+  assert.ok(!source.includes('@nextui-org'), 'Nextra documentation UI should not depend on NextUI')
+}
+
 const outputFiles = await readdir(outputRoot, { recursive: true })
 const cssFiles = outputFiles.filter((file) => file.endsWith('.css'))
 const css = (
@@ -217,4 +286,6 @@ const css = (
 
 assert.ok(css.includes('--echo-primary'), 'static CSS should include Echo UI styles')
 
-console.log('Nextra static output exposes the bilingual landing and guide experience.')
+console.log(
+  'Nextra static output exposes bilingual guides, controller routes, API references, and live Echo UI demos.',
+)

--- a/tests/button.test.tsx
+++ b/tests/button.test.tsx
@@ -13,4 +13,29 @@ describe('Button', () => {
 
     expect(onClick).toHaveBeenCalledOnce()
   })
+
+  it('forwards native div attributes from Button.Group', () => {
+    render(
+      <Button.Group aria-label="Waveform" data-testid="waveform-group" role="group">
+        <Button value="sine">Sine</Button>
+      </Button.Group>,
+    )
+
+    const group = screen.getByTestId('waveform-group')
+    expect(group.getAttribute('aria-label')).toBe('Waveform')
+    expect(group.getAttribute('role')).toBe('group')
+  })
+
+  it.each([0, false, ''])('reports a falsy grouped value (%j)', (value) => {
+    const onChange = vi.fn()
+
+    render(
+      <Button.Group value="selected" onChange={onChange}>
+        <Button value={value}>Option</Button>
+      </Button.Group>,
+    )
+    fireEvent.click(screen.getByRole('button', { name: 'Option' }))
+
+    expect(onChange).toHaveBeenCalledWith(value)
+  })
 })


### PR DESCRIPTION
## Summary

- add complete English and Chinese Nextra pages for Button, Checkbox, Envelope, Input, Knob, Radio, Slider, and Switch
- add interactive local-package demos, public API references, controlled-state guidance, grouping behavior, and accessibility notes
- add static export assertions and Playwright smoke coverage for every bilingual controller route
- fix Button.Group DOM prop forwarding and support falsy grouped values with regression tests

## Verification

- `pnpm verify`
- 12 unit tests passed
- 30 Nextra pages exported
- all 16 bilingual controller routes loaded and exercised in headless Chrome
- Standards review: no actionable findings
- Spec review: no actionable findings

Closes #81