### PR TITLE
docs: migrate Hook guides to Nextra

### DIFF
--- a/docs-nextra/app/_components/display-docs.module.css
+++ b/docs-nextra/app/_components/display-docs.module.css
@@ -110,6 +110,28 @@
   display: none;
 }
 
+.hookSummary {
+  color: var(--lab-ink);
+  display: grid;
+  font-size: 0.82rem;
+  gap: 0.45rem;
+  min-height: 3.25rem;
+}
+
+.hookSummary output {
+  font: inherit;
+}
+
+.feedback {
+  background: color-mix(in oklch, var(--island-c-danger) 10%, transparent);
+  border: 1px solid color-mix(in oklch, var(--island-c-danger) 35%, transparent);
+  border-radius: 0.35rem;
+  color: var(--island-c-danger);
+  font-size: 0.82rem;
+  margin: 0;
+  padding: 0.75rem;
+}
+
 .action,
 .primaryAction,
 .cardToggle {

--- a/docs-nextra/app/_components/hook-api.tsx
+++ b/docs-nextra/app/_components/hook-api.tsx
@@ -1,0 +1,520 @@
+import type { FC } from 'react'
+import { hookNames } from '../../hook-manifest.mjs'
+import { ApiTable, localizedText as text, type ApiSection, type Locale } from './api-reference'
+
+export type HookName = (typeof hookNames)[number]
+
+type HookApiDefinition = Readonly<{
+  parameters: ApiSection
+  returns: ApiSection
+}>
+
+const definitions: Record<HookName, HookApiDefinition> = {
+  useFetchAudio: {
+    parameters: {
+      name: 'UseFetchAudioProps',
+      inherited: text(
+        'Configuration for requesting and decoding one audio resource.',
+        '用于请求并解码单个音频资源的配置。',
+      ),
+      rows: [
+        {
+          name: 'url',
+          type: 'string',
+          defaultValue: '—',
+          required: true,
+          description: text('Relative or absolute audio URL.', '音频资源的相对或绝对地址。'),
+        },
+        {
+          name: 'requestOptions',
+          type: 'RequestInit',
+          defaultValue: '—',
+          description: text('Options passed to fetch.', '传递给 fetch 的请求选项。'),
+        },
+        {
+          name: 'onSuccess',
+          type: '() => void',
+          defaultValue: '—',
+          description: text('Runs after a successful request.', '请求成功后调用。'),
+        },
+        {
+          name: 'onError',
+          type: '() => void',
+          defaultValue: '—',
+          description: text('Runs when requesting or decoding fails.', '请求或解码失败时调用。'),
+        },
+      ],
+    },
+    returns: {
+      name: 'Return object',
+      inherited: text(
+        'Request state, decoded audio, and the command that starts the request.',
+        '包含请求状态、解码后的音频以及启动请求的方法。',
+      ),
+      rows: [
+        {
+          name: 'fetchAudio',
+          type: '() => Promise<void>',
+          defaultValue: '—',
+          description: text('Requests and decodes the configured URL.', '请求并解码配置的地址。'),
+        },
+        {
+          name: 'audioBuffer',
+          type: 'AudioBuffer | null',
+          defaultValue: 'null',
+          description: text('Decoded audio data when available.', '解码成功后的音频数据。'),
+        },
+        {
+          name: 'pending',
+          type: 'boolean',
+          defaultValue: 'true',
+          description: text('Whether the initial request is pending.', '初始请求是否处于等待状态。'),
+        },
+        {
+          name: 'fetched',
+          type: 'boolean',
+          defaultValue: 'false',
+          description: text('Whether the response was successful.', '响应是否成功。'),
+        },
+        {
+          name: 'error',
+          type: 'boolean',
+          defaultValue: 'false',
+          description: text('Whether requesting or decoding failed.', '请求或解码是否失败。'),
+        },
+        {
+          name: 'errorMessage',
+          type: 'string',
+          defaultValue: "''",
+          description: text('Failure details suitable for diagnostics.', '用于诊断的失败详情。'),
+        },
+        {
+          name: 'response',
+          type: 'Response | null',
+          defaultValue: 'null',
+          description: text('The fetch response when one was received.', '收到响应时对应的 fetch Response。'),
+        },
+      ],
+    },
+  },
+  useOscilloscope: {
+    parameters: {
+      name: 'UseOscilloscopeProps',
+      inherited: text('Configuration for a waveform analyser.', '波形分析器的配置。'),
+      rows: [
+        {
+          name: 'fftSize',
+          type: 'number',
+          defaultValue: '1024',
+          description: text(
+            'Power-of-two analyser size from 16 through 16384.',
+            '16 到 16384 之间、且为 2 的幂的分析器大小。',
+          ),
+        },
+        {
+          name: 'onReady',
+          type: '() => void',
+          defaultValue: '—',
+          description: text('Runs after init creates the analyser.', 'init 创建分析器后调用。'),
+        },
+        {
+          name: 'onError',
+          type: '() => void',
+          defaultValue: '—',
+          description: text('Runs when analyser work fails.', '分析器操作失败时调用。'),
+        },
+      ],
+    },
+    returns: {
+      name: 'Return object',
+      inherited: text('Waveform analyser state and lifecycle commands.', '波形分析器状态与生命周期方法。'),
+      rows: [
+        {
+          name: 'init',
+          type: '() => void',
+          defaultValue: '—',
+          description: text('Creates the Tone waveform analyser.', '创建 Tone 波形分析器。'),
+        },
+        {
+          name: 'analyser',
+          type: 'MutableRefObject<Tone.Analyser | null>',
+          defaultValue: 'null',
+          description: text('Analyser node to connect to the source chain.', '连接到音频源链的分析器节点。'),
+        },
+        {
+          name: 'data',
+          type: 'OscilloscopeDataPoint[]',
+          defaultValue: '[]',
+          description: text('Latest indexed time-domain samples.', '最新的带索引时域采样。'),
+        },
+        {
+          name: 'getData',
+          type: '() => void',
+          defaultValue: '—',
+          description: text('Reads one waveform frame.', '读取一帧波形数据。'),
+        },
+        {
+          name: 'observer',
+          type: '() => void',
+          defaultValue: '—',
+          description: text('Starts requestAnimationFrame sampling.', '启动 requestAnimationFrame 采样。'),
+        },
+        {
+          name: 'cancelObserve',
+          type: '() => void',
+          defaultValue: '—',
+          description: text('Stops sampling and clears data.', '停止采样并清空数据。'),
+        },
+        {
+          name: 'error',
+          type: 'boolean',
+          defaultValue: 'false',
+          description: text('Whether analyser work failed.', '分析器操作是否失败。'),
+        },
+        {
+          name: 'errorMessage',
+          type: 'string',
+          defaultValue: "''",
+          description: text('Failure details.', '失败详情。'),
+        },
+      ],
+    },
+  },
+  usePlayer: {
+    parameters: {
+      name: 'UsePlayerProps',
+      inherited: text('Initial playback values and lifecycle callbacks.', '初始播放值与生命周期回调。'),
+      rows: [
+        {
+          name: 'volume',
+          type: 'number',
+          defaultValue: '5',
+          description: text('Initial gain in decibels.', '初始增益（分贝）。'),
+        },
+        {
+          name: 'loop',
+          type: 'boolean',
+          defaultValue: 'false',
+          description: text('Whether playback repeats.', '是否循环播放。'),
+        },
+        {
+          name: 'mute',
+          type: 'boolean',
+          defaultValue: 'false',
+          description: text('Whether playback starts muted.', '是否以静音状态开始。'),
+        },
+        ...['onReady', 'onPlay', 'onPause', 'onStop', 'onFinish', 'onError'].map((name) => ({
+          name,
+          type: '() => void',
+          defaultValue: '—',
+          description: text(
+            `Runs for the ${name.slice(2).toLowerCase()} lifecycle event.`,
+            `在 ${name.slice(2).toLowerCase()} 生命周期事件发生时调用。`,
+          ),
+        })),
+      ],
+    },
+    returns: {
+      name: 'Return object',
+      inherited: text('Player state, controls, and observation commands.', '播放器状态、控制与监听方法。'),
+      rows: [
+        {
+          name: 'init',
+          type: '(audioBuffer: AudioBuffer, chain?: Tone.InputNode[]) => void',
+          defaultValue: '—',
+          description: text('Creates a player and connects its node chain.', '创建播放器并连接节点链。'),
+        },
+        {
+          name: 'player',
+          type: 'MutableRefObject<Tone.Player | null>',
+          defaultValue: 'null',
+          description: text('Underlying Tone Player.', '底层 Tone Player。'),
+        },
+        {
+          name: 'audioDuration',
+          type: 'MutableRefObject<number>',
+          defaultValue: '0',
+          description: text('Loaded duration in seconds.', '已加载音频时长（秒）。'),
+        },
+        ...[
+          ['isReady', 'boolean', 'false', 'Whether init completed.', 'init 是否完成。'],
+          ['isPlaying', 'boolean', 'false', 'Whether playback is active.', '是否正在播放。'],
+          ['isFinish', 'boolean', 'false', 'Whether playback reached the end.', '播放是否已结束。'],
+          ['volume', 'number', '5', 'Current gain in decibels.', '当前增益（分贝）。'],
+          ['loop', 'boolean', 'false', 'Current loop setting.', '当前循环设置。'],
+          ['mute', 'boolean', 'false', 'Current mute setting.', '当前静音设置。'],
+          ['time', 'number', '0', 'Observed playback time in seconds.', '监听到的播放时间（秒）。'],
+          ['percentage', 'number', '0', 'Observed progress from 0 to 100.', '0 到 100 的播放进度。'],
+          ['pickTime', 'MutableRefObject<number>', '0', 'Requested playback offset.', '请求的播放偏移量。'],
+        ].map(([name, type, defaultValue, en, zh]) => ({
+          name,
+          type,
+          defaultValue,
+          description: text(en, zh),
+        })),
+        ...[
+          ['play', '() => void', 'Starts or resumes playback.', '开始或继续播放。'],
+          ['pause', '() => void', 'Pauses and keeps the current offset.', '暂停并保留当前位置。'],
+          ['stop', '() => void', 'Stops and resets playback.', '停止并重置播放。'],
+          ['getTime', '() => void', 'Reads the current time into state.', '将当前时间读取到状态中。'],
+          ['setPickTime', '(time: number) => void', 'Sets the next playback offset.', '设置下一次播放偏移量。'],
+          ['setVolume', 'Dispatch<SetStateAction<number>>', 'Updates gain.', '更新增益。'],
+          ['setLoop', 'Dispatch<SetStateAction<boolean>>', 'Updates loop mode.', '更新循环模式。'],
+          ['setMute', 'Dispatch<SetStateAction<boolean>>', 'Updates mute mode.', '更新静音模式。'],
+          ['observe', '() => void', 'Starts animation-frame progress updates.', '启动动画帧进度更新。'],
+          ['cancelObserve', '() => void', 'Stops progress updates.', '停止进度更新。'],
+        ].map(([name, type, en, zh]) => ({
+          name,
+          type,
+          defaultValue: '—',
+          description: text(en, zh),
+        })),
+        {
+          name: 'error',
+          type: 'boolean',
+          defaultValue: 'false',
+          description: text('Whether player work failed.', '播放器操作是否失败。'),
+        },
+        {
+          name: 'errorMessage',
+          type: 'string',
+          defaultValue: "''",
+          description: text('Failure details.', '失败详情。'),
+        },
+      ],
+    },
+  },
+  useSpectrogram: {
+    parameters: {
+      name: 'UseSpectrogramProps',
+      inherited: text('Configuration for an FFT analyser.', 'FFT 分析器的配置。'),
+      rows: [
+        {
+          name: 'fftSize',
+          type: 'number',
+          defaultValue: '1024',
+          description: text(
+            'Power-of-two analyser size from 16 through 16384.',
+            '16 到 16384 之间、且为 2 的幂的分析器大小。',
+          ),
+        },
+        {
+          name: 'onReady',
+          type: '() => void',
+          defaultValue: '—',
+          description: text('Optional ready callback.', '可选的就绪回调。'),
+        },
+        {
+          name: 'onError',
+          type: '() => void',
+          defaultValue: '—',
+          description: text('Optional error callback.', '可选的错误回调。'),
+        },
+      ],
+    },
+    returns: {
+      name: 'Return object',
+      inherited: text('FFT analyser state and lifecycle commands.', 'FFT 分析器状态与生命周期方法。'),
+      rows: [
+        {
+          name: 'init',
+          type: '() => void',
+          defaultValue: '—',
+          description: text('Creates the Tone FFT analyser.', '创建 Tone FFT 分析器。'),
+        },
+        {
+          name: 'analyser',
+          type: 'MutableRefObject<Tone.Analyser | null>',
+          defaultValue: 'null',
+          description: text('Analyser node to connect to the source chain.', '连接到音频源链的分析器节点。'),
+        },
+        {
+          name: 'data',
+          type: 'SpectrogramDataPoint[]',
+          defaultValue: '[]',
+          description: text('Latest frequency-bin amplitudes.', '最新的频率分箱振幅。'),
+        },
+        {
+          name: 'getData',
+          type: '() => void',
+          defaultValue: '—',
+          description: text('Reads one FFT frame.', '读取一帧 FFT 数据。'),
+        },
+        {
+          name: 'observe',
+          type: '() => void',
+          defaultValue: '—',
+          description: text('Starts requestAnimationFrame sampling.', '启动 requestAnimationFrame 采样。'),
+        },
+        {
+          name: 'cancelObserve',
+          type: '() => void',
+          defaultValue: '—',
+          description: text('Stops sampling and clears data.', '停止采样并清空数据。'),
+        },
+        {
+          name: 'error',
+          type: 'boolean',
+          defaultValue: 'false',
+          description: text('Whether analyser work failed.', '分析器操作是否失败。'),
+        },
+        {
+          name: 'errorMessage',
+          type: 'string',
+          defaultValue: "''",
+          description: text('Failure details.', '失败详情。'),
+        },
+      ],
+    },
+  },
+  useVuMeter: {
+    parameters: {
+      name: 'UseVuMeterProps',
+      inherited: text('Initial mono or stereo meter state and callbacks.', '初始单声道或立体声电平与回调。'),
+      rows: [
+        {
+          name: 'value',
+          type: 'number | number[]',
+          defaultValue: '—',
+          required: true,
+          description: text('Initial mono value or stereo pair in dB.', '初始单声道值或立体声分贝值对。'),
+        },
+        {
+          name: 'onReady',
+          type: '() => void',
+          defaultValue: '—',
+          description: text('Runs after init creates the meter.', 'init 创建电平表后调用。'),
+        },
+        {
+          name: 'onError',
+          type: '() => void',
+          defaultValue: '—',
+          description: text('Runs when meter work fails.', '电平表操作失败时调用。'),
+        },
+      ],
+    },
+    returns: {
+      name: 'Return object',
+      inherited: text('Meter state and lifecycle commands.', '电平表状态与生命周期方法。'),
+      rows: [
+        {
+          name: 'init',
+          type: '() => void',
+          defaultValue: '—',
+          description: text('Creates a mono meter or stereo split graph.', '创建单声道电平表或立体声分离图。'),
+        },
+        {
+          name: 'meter',
+          type: 'MutableRefObject<Tone.Meter | Tone.Split | null>',
+          defaultValue: 'null',
+          description: text('Node to connect to the source chain.', '连接到音频源链的节点。'),
+        },
+        {
+          name: 'value',
+          type: 'number | number[]',
+          defaultValue: 'input value',
+          description: text('Latest mono or stereo reading.', '最新的单声道或立体声读数。'),
+        },
+        {
+          name: 'getValue',
+          type: '() => void',
+          defaultValue: '—',
+          description: text('Reads one meter value.', '读取一次电平值。'),
+        },
+        {
+          name: 'observe',
+          type: '() => void',
+          defaultValue: '—',
+          description: text('Starts requestAnimationFrame readings.', '启动 requestAnimationFrame 读数。'),
+        },
+        {
+          name: 'cancelObserve',
+          type: '() => void',
+          defaultValue: '—',
+          description: text('Stops readings and restores the initial value.', '停止读数并恢复初始值。'),
+        },
+        {
+          name: 'error',
+          type: 'boolean',
+          defaultValue: 'false',
+          description: text('Whether meter work failed.', '电平表操作是否失败。'),
+        },
+        {
+          name: 'errorMessage',
+          type: 'string',
+          defaultValue: "''",
+          description: text('Failure details.', '失败详情。'),
+        },
+      ],
+    },
+  },
+  useWaveform: {
+    parameters: {
+      name: 'UseWaveformProps',
+      inherited: text('Configuration for simplifying decoded audio.', '简化已解码音频的配置。'),
+      rows: [
+        {
+          name: 'audioBuffer',
+          type: 'AudioBuffer | null',
+          defaultValue: '—',
+          required: true,
+          description: text('Decoded source audio.', '已解码的源音频。'),
+        },
+        {
+          name: 'channel',
+          type: '1 | 2',
+          defaultValue: '2',
+          description: text('Number of channels to simplify.', '要简化的声道数量。'),
+        },
+        {
+          name: 'samples',
+          type: 'number',
+          defaultValue: '1024',
+          description: text('Output sample count per channel.', '每个声道的输出采样数量。'),
+        },
+      ],
+    },
+    returns: {
+      name: 'Return object',
+      inherited: text('Simplified waveform data and processing state.', '简化后的波形数据与处理状态。'),
+      rows: [
+        {
+          name: 'data',
+          type: 'number[] | number[][]',
+          defaultValue: '[]',
+          description: text('One mono array or an array per channel.', '一个单声道数组或每声道一个数组。'),
+        },
+        {
+          name: 'audioDuration',
+          type: 'MutableRefObject<number>',
+          defaultValue: '0',
+          description: text('Buffer duration in seconds.', '缓冲区时长（秒）。'),
+        },
+        {
+          name: 'error',
+          type: 'boolean',
+          defaultValue: 'false',
+          description: text('Whether waveform processing failed.', '波形处理是否失败。'),
+        },
+        {
+          name: 'errorMessage',
+          type: 'string',
+          defaultValue: "''",
+          description: text('Failure details.', '失败详情。'),
+        },
+      ],
+    },
+  },
+}
+
+type HookApiProps = Readonly<{
+  hook: HookName
+  lang: Locale
+  section: keyof HookApiDefinition
+}>
+
+export const HookApi: FC<HookApiProps> = ({ hook, lang, section }) => (
+  <div data-hook-api={hook} data-hook-api-section={section}>
+    <ApiTable lang={lang} section={definitions[hook][section]} />
+  </div>
+)

--- a/docs-nextra/app/_components/hook-demo.tsx
+++ b/docs-nextra/app/_components/hook-demo.tsx
@@ -1,0 +1,652 @@
+'use client'
+
+import {
+  Oscilloscope,
+  Spectrogram,
+  VuMeter,
+  Waveform,
+  useFetchAudio,
+  useOscilloscope,
+  usePlayer,
+  useSpectrogram,
+  useVuMeter,
+  useWaveform,
+} from '@nafr/echo-ui'
+import {
+  type ChangeEvent,
+  type FC,
+  type ReactNode,
+  useCallback,
+  useEffect,
+  useId,
+  useRef,
+  useState,
+} from 'react'
+import type { Locale } from './api-reference'
+import styles from './display-docs.module.css'
+import type { HookName } from './hook-api'
+
+type AudioSource = 'bundled' | 'unavailable'
+type HookDemoStatus = 'idle' | 'loading' | 'ready' | 'playing' | 'stopped' | 'error'
+type ActiveHookName = 'useOscilloscope' | 'usePlayer' | 'useSpectrogram' | 'useVuMeter'
+
+const basePath = process.env.NEXT_PUBLIC_DOCS_BASE_PATH ?? ''
+
+const sourceUrls: Record<AudioSource, string> = {
+  bundled: `${basePath}/audios/demo-loop.mp3`,
+  unavailable: `${basePath}/audios/unavailable-demo.mp3`,
+}
+
+const copy = {
+  en: {
+    bundled: 'Bundled audio loop',
+    error: 'Unavailable source could not be loaded. Choose the bundled loop and try again.',
+    fail: 'Simulate graph failure',
+    idle: 'Choose a source, then start from a user action.',
+    load: 'Load audio',
+    loading: 'Requesting and decoding audio…',
+    playing: 'Audio and observation are running.',
+    prepare: 'Prepare audio',
+    ready: 'Decoded audio ready',
+    source: 'Audio source',
+    start: 'Start',
+    stop: 'Stop and release',
+    stopped: 'Playback, graph nodes, and animation work released.',
+    unavailable: 'Unavailable source',
+    waveform: 'Generate waveform',
+  },
+  zh: {
+    bundled: '内置音频循环',
+    error: '不可用的音频源无法加载。请选择内置音频循环后重试。',
+    fail: '模拟音频图故障',
+    idle: '选择音频源，然后通过用户操作启动。',
+    load: '加载音频',
+    loading: '正在请求并解码音频…',
+    playing: '音频与监听任务正在运行。',
+    prepare: '准备音频',
+    ready: '解码后的音频已就绪',
+    source: '音频源',
+    start: '开始',
+    stop: '停止并释放',
+    stopped: '播放、音频图节点与动画任务已释放。',
+    unavailable: '不可用的音频源',
+    waveform: '生成波形',
+  },
+} as const
+
+const statusText = (status: HookDemoStatus, lang: Locale) => copy[lang][status]
+
+type DemoShellProps = Readonly<{
+  active: boolean
+  children: ReactNode
+  connected: boolean
+  connectionCount?: number
+  hook: HookName
+  lang: Locale
+  onSourceChange: (source: AudioSource) => void
+  source: AudioSource
+  status: HookDemoStatus
+}>
+
+const DemoShell: FC<DemoShellProps> = ({
+  active,
+  children,
+  connected,
+  connectionCount = 0,
+  hook,
+  lang,
+  onSourceChange,
+  source,
+  status,
+}) => {
+  const labels = copy[lang]
+  const sourceId = useId()
+
+  const changeSource = (event: ChangeEvent<HTMLSelectElement>) => {
+    onSourceChange(event.target.value as AudioSource)
+  }
+
+  return (
+    <section
+      className={styles.demo}
+      data-animation-active={active}
+      data-audio-state={status}
+      data-connection-count={connectionCount}
+      data-graph-connected={connected}
+      data-hook-demo={hook}
+      data-source={source}
+    >
+      <header className={styles.demoHeader}>
+        <span className={styles.signalLabel}>{lang === 'zh' ? '预览' : 'Preview'}</span>
+        <p className={styles.demoStatus} aria-live="polite">
+          {statusText(status, lang)}
+        </p>
+      </header>
+      <div className={styles.instrument}>
+        <div className={styles.parameterGrid}>
+          <label htmlFor={sourceId}>
+            {labels.source}
+            <select id={sourceId} onChange={changeSource} value={source}>
+              <option value="bundled">{labels.bundled}</option>
+              <option value="unavailable">{labels.unavailable}</option>
+            </select>
+          </label>
+        </div>
+        {children}
+      </div>
+    </section>
+  )
+}
+
+type StaticSessionProps = Readonly<{
+  lang: Locale
+  onStatusChange: (status: HookDemoStatus) => void
+  source: AudioSource
+  status: HookDemoStatus
+}>
+
+const FetchAudioSession: FC<StaticSessionProps> = ({ lang, onStatusChange, source, status }) => {
+  const labels = copy[lang]
+  const [requested, setRequested] = useState(false)
+  const { audioBuffer, error, fetchAudio } = useFetchAudio({ url: sourceUrls[source] })
+
+  useEffect(() => {
+    if (audioBuffer) onStatusChange('ready')
+  }, [audioBuffer, onStatusChange])
+
+  useEffect(() => {
+    if (error) onStatusChange('error')
+  }, [error, onStatusChange])
+
+  const load = async () => {
+    setRequested(true)
+    onStatusChange('loading')
+    await fetchAudio()
+  }
+
+  return (
+    <>
+      <div className={styles.hookSummary} aria-live="polite">
+        <output>{statusText(status, lang)}</output>
+        {audioBuffer && (
+          <output>
+            {audioBuffer.duration.toFixed(2)} s · {audioBuffer.numberOfChannels}{' '}
+            {lang === 'zh' ? '声道' : audioBuffer.numberOfChannels === 1 ? 'channel' : 'channels'}
+          </output>
+        )}
+      </div>
+      <div className={styles.controls}>
+        <button
+          className={styles.primaryAction}
+          disabled={status === 'loading'}
+          onClick={load}
+          type="button"
+        >
+          {labels.load}
+        </button>
+      </div>
+      {requested && status === 'error' && (
+        <p className={styles.feedback} role="alert">
+          {labels.error}
+        </p>
+      )}
+    </>
+  )
+}
+
+const WaveformSession: FC<StaticSessionProps> = ({ lang, onStatusChange, source, status }) => {
+  const labels = copy[lang]
+  const [requested, setRequested] = useState(false)
+  const fetchedAudio = useFetchAudio({ url: sourceUrls[source] })
+  const waveform = useWaveform({ audioBuffer: fetchedAudio.audioBuffer, channel: 1, samples: 256 })
+
+  useEffect(() => {
+    if (waveform.data.length > 0) onStatusChange('ready')
+  }, [onStatusChange, waveform.data])
+
+  useEffect(() => {
+    if (fetchedAudio.error || waveform.error) onStatusChange('error')
+  }, [fetchedAudio.error, onStatusChange, waveform.error])
+
+  const load = async () => {
+    setRequested(true)
+    onStatusChange('loading')
+    await fetchedAudio.fetchAudio()
+  }
+
+  return (
+    <>
+      <div className={styles.readout}>
+        {waveform.data.length > 0 ? (
+          <Waveform
+            aria-label={lang === 'zh' ? '生成的音频波形' : 'Generated audio waveform'}
+            audioDuration={waveform.audioDuration.current}
+            className={styles.waveform}
+            data={waveform.data}
+            role="img"
+          />
+        ) : (
+          <output className={styles.hookSummary}>{statusText(status, lang)}</output>
+        )}
+      </div>
+      <div className={styles.controls}>
+        <button
+          className={styles.primaryAction}
+          disabled={status === 'loading'}
+          onClick={load}
+          type="button"
+        >
+          {labels.waveform}
+        </button>
+      </div>
+      {requested && status === 'error' && (
+        <p className={styles.feedback} role="alert">
+          {labels.error}
+        </p>
+      )}
+    </>
+  )
+}
+
+const StaticHookDemo: FC<{ hook: 'useFetchAudio' | 'useWaveform'; lang: Locale }> = ({
+  hook,
+  lang,
+}) => {
+  const [source, setSource] = useState<AudioSource>('bundled')
+  const [status, setStatus] = useState<HookDemoStatus>('idle')
+
+  const changeSource = (nextSource: AudioSource) => {
+    setStatus('idle')
+    setSource(nextSource)
+  }
+
+  const Session = hook === 'useFetchAudio' ? FetchAudioSession : WaveformSession
+
+  return (
+    <DemoShell
+      active={false}
+      connected={false}
+      hook={hook}
+      lang={lang}
+      onSourceChange={changeSource}
+      source={source}
+      status={status}
+    >
+      <Session key={source} lang={lang} onStatusChange={setStatus} source={source} status={status} />
+    </DemoShell>
+  )
+}
+
+type ActiveSessionCallbacks = Readonly<{
+  onConnected: () => void
+  onError: () => void
+  onPlaying: () => void
+  onRelease: () => void
+  onStatusChange: (status: HookDemoStatus) => void
+}>
+
+type ActiveSessionProps = ActiveSessionCallbacks &
+  Readonly<{
+    lang: Locale
+    source: AudioSource
+    status: HookDemoStatus
+  }>
+
+type ActiveControlsProps = Readonly<{
+  lang: Locale
+  onFail: () => void
+  onPrepare: () => Promise<void>
+  onStart: () => Promise<void>
+  onStop: () => void
+  status: HookDemoStatus
+}>
+
+const ActiveControls: FC<ActiveControlsProps> = ({
+  lang,
+  onFail,
+  onPrepare,
+  onStart,
+  onStop,
+  status,
+}) => {
+  const labels = copy[lang]
+
+  return (
+    <div className={styles.controls}>
+      <button
+        className={styles.action}
+        disabled={status === 'loading' || status === 'playing'}
+        onClick={onPrepare}
+        type="button"
+      >
+        {labels.prepare}
+      </button>
+      <button
+        className={styles.primaryAction}
+        disabled={status !== 'ready'}
+        onClick={onStart}
+        type="button"
+      >
+        {labels.start}
+      </button>
+      <button
+        className={styles.action}
+        disabled={status !== 'playing'}
+        onClick={onStop}
+        type="button"
+      >
+        {labels.stop}
+      </button>
+      <button
+        className={styles.action}
+        disabled={status !== 'playing'}
+        onClick={onFail}
+        type="button"
+      >
+        {labels.fail}
+      </button>
+    </div>
+  )
+}
+
+type PlayerChainNode = NonNullable<Parameters<ReturnType<typeof usePlayer>['init']>[1]>[number]
+
+type AnalysisAdapter = Readonly<{
+  cancel: () => void
+  error: boolean
+  getNode: () => PlayerChainNode | null
+  init: () => void
+  observe: () => void
+  visualization: ReactNode
+}>
+
+type ActiveAudioSessionOptions = ActiveSessionCallbacks &
+  Readonly<{
+    analysis?: AnalysisAdapter
+    source: AudioSource
+  }>
+
+const useActiveAudioSession = ({
+  analysis,
+  onConnected,
+  onError,
+  onPlaying,
+  onRelease,
+  onStatusChange,
+  source,
+}: ActiveAudioSessionOptions) => {
+  const initialized = useRef(false)
+  const cleanupRef = useRef<() => void>(() => undefined)
+  const fetchedAudio = useFetchAudio({ onError, url: sourceUrls[source] })
+  const player = usePlayer({ onError })
+
+  cleanupRef.current = () => {
+    analysis?.cancel()
+    player.cancelObserve()
+  }
+
+  useEffect(() => () => cleanupRef.current(), [])
+
+  useEffect(() => {
+    if (analysis?.error) onError()
+  }, [analysis?.error, onError])
+
+  useEffect(() => {
+    if (!fetchedAudio.audioBuffer || initialized.current) return
+    initialized.current = true
+    analysis?.init()
+    const node = analysis?.getNode() ?? null
+    if (analysis && !node) {
+      onError()
+      return
+    }
+    player.init(fetchedAudio.audioBuffer, node ? [node] : [])
+    onConnected()
+  }, [analysis, fetchedAudio.audioBuffer, onConnected, onError, player])
+
+  const prepare = async () => {
+    onStatusChange('loading')
+    await fetchedAudio.fetchAudio()
+  }
+
+  const start = async () => {
+    try {
+      await player.player.current?.context.resume()
+      player.play()
+      player.observe()
+      analysis?.observe()
+      onPlaying()
+    } catch {
+      onError()
+    }
+  }
+
+  const stop = () => {
+    analysis?.cancel()
+    player.cancelObserve()
+    player.stop()
+    onRelease()
+  }
+
+  return { fail: onError, player, prepare, start, stop }
+}
+
+const PlayerSession: FC<ActiveSessionProps> = (props) => {
+  const session = useActiveAudioSession(props)
+
+  return (
+    <>
+      <div className={styles.hookSummary} aria-live="polite">
+        <output>{statusText(props.status, props.lang)}</output>
+        <output>
+          {session.player.time.toFixed(2)} s · {session.player.percentage.toFixed(1)}%
+        </output>
+      </div>
+      <ActiveControls
+        lang={props.lang}
+        onFail={session.fail}
+        onPrepare={session.prepare}
+        onStart={session.start}
+        onStop={session.stop}
+        status={props.status}
+      />
+      {props.status === 'error' && (
+        <p className={styles.feedback} role="alert">
+          {copy[props.lang].error}
+        </p>
+      )}
+    </>
+  )
+}
+
+type AnalyzerSessionProps = ActiveSessionProps & Readonly<{ analysis: AnalysisAdapter }>
+
+const AnalyzerSession: FC<AnalyzerSessionProps> = (props) => {
+  const session = useActiveAudioSession(props)
+
+  return (
+    <>
+      <div className={styles.readout}>{props.analysis.visualization}</div>
+      <ActiveControls
+        lang={props.lang}
+        onFail={session.fail}
+        onPrepare={session.prepare}
+        onStart={session.start}
+        onStop={session.stop}
+        status={props.status}
+      />
+      {props.status === 'error' && (
+        <p className={styles.feedback} role="alert">
+          {copy[props.lang].error}
+        </p>
+      )}
+    </>
+  )
+}
+
+const OscilloscopeSession: FC<ActiveSessionProps> = (props) => {
+  const analysis = useOscilloscope({ onError: props.onError })
+  return (
+    <AnalyzerSession
+      {...props}
+      analysis={{
+        cancel: analysis.cancelObserve,
+        error: analysis.error,
+        getNode: () => analysis.analyser.current,
+        init: analysis.init,
+        observe: analysis.observer,
+        visualization: (
+          <Oscilloscope
+            aria-label={props.lang === 'zh' ? 'Hook 实时示波器' : 'Live Hook oscilloscope'}
+            amplitudeRange={[-1, 1]}
+            className={styles.chart}
+            data={analysis.data}
+            role="img"
+          />
+        ),
+      }}
+    />
+  )
+}
+
+const SpectrogramSession: FC<ActiveSessionProps> = (props) => {
+  const analysis = useSpectrogram({ fftSize: 512, onError: props.onError })
+  return (
+    <AnalyzerSession
+      {...props}
+      analysis={{
+        cancel: analysis.cancelObserve,
+        error: analysis.error,
+        getNode: () => analysis.analyser.current,
+        init: analysis.init,
+        observe: analysis.observe,
+        visualization: (
+          <Spectrogram
+            aria-label={props.lang === 'zh' ? 'Hook 实时频谱图' : 'Live Hook spectrum'}
+            axis
+            className={styles.chart}
+            data={analysis.data}
+            fftSize={512}
+            role="img"
+          />
+        ),
+      }}
+    />
+  )
+}
+
+const VuMeterSession: FC<ActiveSessionProps> = (props) => {
+  const analysis = useVuMeter({ onError: props.onError, value: -60 })
+  return (
+    <AnalyzerSession
+      {...props}
+      analysis={{
+        cancel: analysis.cancelObserve,
+        error: analysis.error,
+        getNode: () => analysis.meter.current,
+        init: analysis.init,
+        observe: analysis.observe,
+        visualization: (
+          <div className={styles.meter}>
+            <VuMeter horizontal lumpsQuantity={36} value={analysis.value} />
+            <output className={styles.levelValue}>
+              {typeof analysis.value === 'number' ? analysis.value.toFixed(1) : 'stereo'} dB
+            </output>
+          </div>
+        ),
+      }}
+    />
+  )
+}
+
+const ActiveHookDemo: FC<{ hook: ActiveHookName; lang: Locale }> = ({ hook, lang }) => {
+  const [source, setSource] = useState<AudioSource>('bundled')
+  const [status, setStatus] = useState<HookDemoStatus>('idle')
+  const [active, setActive] = useState(false)
+  const [connected, setConnected] = useState(false)
+  const [connectionCount, setConnectionCount] = useState(0)
+  const [sessionVersion, setSessionVersion] = useState(0)
+
+  const onConnected = useCallback(() => {
+    setConnected(true)
+    setConnectionCount((count) => count + 1)
+    setStatus('ready')
+  }, [])
+
+  const onError = useCallback(() => {
+    setActive(false)
+    setConnected(false)
+    setStatus('error')
+    setSessionVersion((version) => version + 1)
+  }, [])
+
+  const onPlaying = useCallback(() => {
+    setActive(true)
+    setConnected(true)
+    setStatus('playing')
+  }, [])
+
+  const onRelease = useCallback(() => {
+    setActive(false)
+    setConnected(false)
+    setStatus('stopped')
+    setSessionVersion((version) => version + 1)
+  }, [])
+
+  const changeSource = (nextSource: AudioSource) => {
+    setActive(false)
+    setConnected(false)
+    setStatus('idle')
+    setSource(nextSource)
+    setSessionVersion((version) => version + 1)
+  }
+
+  const sessionProps: ActiveSessionProps = {
+    lang,
+    onConnected,
+    onError,
+    onPlaying,
+    onRelease,
+    onStatusChange: setStatus,
+    source,
+    status,
+  }
+
+  const session =
+    hook === 'useOscilloscope' ? (
+      <OscilloscopeSession {...sessionProps} />
+    ) : hook === 'useSpectrogram' ? (
+      <SpectrogramSession {...sessionProps} />
+    ) : hook === 'useVuMeter' ? (
+      <VuMeterSession {...sessionProps} />
+    ) : (
+      <PlayerSession {...sessionProps} />
+    )
+
+  return (
+    <DemoShell
+      active={active}
+      connected={connected}
+      connectionCount={connectionCount}
+      hook={hook}
+      lang={lang}
+      onSourceChange={changeSource}
+      source={source}
+      status={status}
+    >
+      <div key={`${source}-${sessionVersion}`}>{session}</div>
+    </DemoShell>
+  )
+}
+
+type HookDemoProps = Readonly<{
+  hook: HookName
+  lang: Locale
+}>
+
+export const HookDemo: FC<HookDemoProps> = ({ hook, lang }) => {
+  if (hook === 'useFetchAudio' || hook === 'useWaveform') {
+    return <StaticHookDemo hook={hook} lang={lang} />
+  }
+  return <ActiveHookDemo hook={hook} lang={lang} />
+}

--- a/docs-nextra/content/en/_meta.ts
+++ b/docs-nextra/content/en/_meta.ts
@@ -26,7 +26,7 @@ const meta: MetaRecord = {
     type: 'page',
   },
   hook: {
-    href: '/en/guide/declaration/#about-the-hooks',
+    href: '/en/hook/useFetchAudio/',
     title: 'Hook',
     type: 'page',
   },

--- a/docs-nextra/content/en/hook/_meta.ts
+++ b/docs-nextra/content/en/hook/_meta.ts
@@ -1,0 +1,12 @@
+import type { MetaRecord } from 'nextra'
+
+const meta: MetaRecord = {
+  useFetchAudio: 'useFetchAudio',
+  useOscilloscope: 'useOscilloscope',
+  usePlayer: 'usePlayer',
+  useSpectrogram: 'useSpectrogram',
+  useVuMeter: 'useVuMeter',
+  useWaveform: 'useWaveform',
+}
+
+export default meta

--- a/docs-nextra/content/en/hook/useFetchAudio.mdx
+++ b/docs-nextra/content/en/hook/useFetchAudio.mdx
@@ -1,0 +1,41 @@
+---
+title: useFetchAudio
+description: Request and decode audio data with the useFetchAudio Hook.
+---
+
+import { HookApi } from '@/app/_components/hook-api'
+import { HookDemo } from '@/app/_components/hook-demo'
+
+# `useFetchAudio`
+
+`useFetchAudio` requests an audio resource and decodes its response into an `AudioBuffer` for playback, analysis, or waveform processing.
+
+[View source](https://github.com/codeacme17/echo-ui/blob/main/packages/hooks/useFetchAudio.ts)
+
+## Import
+
+```tsx
+import { useFetchAudio, type UseFetchAudioProps } from '@nafr/echo-ui'
+```
+
+## Live example
+
+Load the bundled audio from a user action, or choose the unavailable source to see recoverable failure feedback.
+
+<HookDemo hook="useFetchAudio" lang="en" />
+
+<h2 id="parameters">Parameters</h2>
+
+<HookApi hook="useFetchAudio" lang="en" section="parameters" />
+
+<h2 id="return-value">Return value</h2>
+
+<HookApi hook="useFetchAudio" lang="en" section="returns" />
+
+<h2 id="lifecycle">Lifecycle</h2>
+
+Call `fetchAudio` from a user action when the browser requires audio startup permission. Wait for `audioBuffer` before initializing players or analysers. When the URL changes, release consumers of the previous buffer before starting the next request.
+
+<h2 id="errors">Errors</h2>
+
+HTTP failures and decoding failures set `error` and `errorMessage`, and call `onError`. Keep a visible retry action in the interface; cross-origin URLs must permit the request through CORS.

--- a/docs-nextra/content/en/hook/useOscilloscope.mdx
+++ b/docs-nextra/content/en/hook/useOscilloscope.mdx
@@ -1,0 +1,41 @@
+---
+title: useOscilloscope
+description: Observe real-time time-domain audio with the useOscilloscope Hook.
+---
+
+import { HookApi } from '@/app/_components/hook-api'
+import { HookDemo } from '@/app/_components/hook-demo'
+
+# `useOscilloscope`
+
+`useOscilloscope` creates a Tone waveform analyser and converts each frame into indexed amplitude points for the `Oscilloscope` component.
+
+[View source](https://github.com/codeacme17/echo-ui/blob/main/packages/hooks/useOscilloscope.ts)
+
+## Import
+
+```tsx
+import { Oscilloscope, useOscilloscope, type UseOscilloscopeProps } from '@nafr/echo-ui'
+```
+
+## Live example
+
+Prepare the bundled source, start observation from a user action, stop it, or switch to an unavailable source to inspect failure feedback.
+
+<HookDemo hook="useOscilloscope" lang="en" />
+
+<h2 id="parameters">Parameters</h2>
+
+<HookApi hook="useOscilloscope" lang="en" section="parameters" />
+
+<h2 id="return-value">Return value</h2>
+
+<HookApi hook="useOscilloscope" lang="en" section="returns" />
+
+<h2 id="lifecycle">Lifecycle</h2>
+
+Call `init` once, connect `analyser.current` into the source chain, then call `observer` once while playback is active. Call `cancelObserve` before stopping or switching sources. The Hook disposes its analyser on unmount; the source or player must also be stopped and disposed by its owner.
+
+<h2 id="errors">Errors</h2>
+
+Invalid `fftSize` values, unavailable Web Audio APIs, or analyser reads after teardown can set `error` and `errorMessage` and call `onError`. Disable start controls until both the source and analyser are ready.

--- a/docs-nextra/content/en/hook/usePlayer.mdx
+++ b/docs-nextra/content/en/hook/usePlayer.mdx
@@ -1,0 +1,41 @@
+---
+title: usePlayer
+description: Control Tone-based playback and progress with the usePlayer Hook.
+---
+
+import { HookApi } from '@/app/_components/hook-api'
+import { HookDemo } from '@/app/_components/hook-demo'
+
+# `usePlayer`
+
+`usePlayer` owns a Tone Player, playback state, progress observation, gain, looping, and mute controls for a decoded `AudioBuffer`.
+
+[View source](https://github.com/codeacme17/echo-ui/blob/main/packages/hooks/usePlayer.ts)
+
+## Import
+
+```tsx
+import { usePlayer, type UsePlayerProps } from '@nafr/echo-ui'
+```
+
+## Live example
+
+Load the bundled buffer, start the audio context from a user action, observe progress, then stop or switch sources without leaving playback or animation work active.
+
+<HookDemo hook="usePlayer" lang="en" />
+
+<h2 id="parameters">Parameters</h2>
+
+<HookApi hook="usePlayer" lang="en" section="parameters" />
+
+<h2 id="return-value">Return value</h2>
+
+<HookApi hook="usePlayer" lang="en" section="returns" />
+
+<h2 id="lifecycle">Lifecycle</h2>
+
+Fetch and decode the source before calling `init`. Resume the browser audio context from a click or key action, call `observe` only once while playing, and pair it with `cancelObserve`. Before switching sources or unmounting, stop playback, cancel observation, and let the Hook dispose its Player. Do not append `Tone.Destination` to `chain`; `init` does that for you.
+
+<h2 id="errors">Errors</h2>
+
+Playback before `init`, invalid offsets, unavailable browser audio permission, and invalid chain nodes can fail. The Hook exposes `error` and `errorMessage` and calls `onError`; keep retry and stop controls available when recovery is possible.

--- a/docs-nextra/content/en/hook/useSpectrogram.mdx
+++ b/docs-nextra/content/en/hook/useSpectrogram.mdx
@@ -1,0 +1,41 @@
+---
+title: useSpectrogram
+description: Observe real-time FFT data with the useSpectrogram Hook.
+---
+
+import { HookApi } from '@/app/_components/hook-api'
+import { HookDemo } from '@/app/_components/hook-demo'
+
+# `useSpectrogram`
+
+`useSpectrogram` creates a Tone FFT analyser and formats its frequency bins for the `Spectrogram` component.
+
+[View source](https://github.com/codeacme17/echo-ui/blob/main/packages/hooks/useSpectrogram.ts)
+
+## Import
+
+```tsx
+import { Spectrogram, useSpectrogram, type UseSpectrogramProps } from '@nafr/echo-ui'
+```
+
+## Live example
+
+Prepare and start the bundled source, stop FFT observation, or switch sources to exercise teardown and failure feedback.
+
+<HookDemo hook="useSpectrogram" lang="en" />
+
+<h2 id="parameters">Parameters</h2>
+
+<HookApi hook="useSpectrogram" lang="en" section="parameters" />
+
+<h2 id="return-value">Return value</h2>
+
+<HookApi hook="useSpectrogram" lang="en" section="returns" />
+
+<h2 id="lifecycle">Lifecycle</h2>
+
+Call `init` once, connect `analyser.current` into the source chain, and call `observe` once during playback. Call `cancelObserve` before stop, source replacement, or manual teardown. The analyser is disposed on unmount, while the source remains the source owner's responsibility.
+
+<h2 id="errors">Errors</h2>
+
+An invalid power-of-two `fftSize`, unsupported Web Audio, or reading a disposed analyser can set `error` and `errorMessage`. Keep the visualization empty and show a retry action instead of continuing the frame loop.

--- a/docs-nextra/content/en/hook/useVuMeter.mdx
+++ b/docs-nextra/content/en/hook/useVuMeter.mdx
@@ -1,0 +1,41 @@
+---
+title: useVuMeter
+description: Observe mono or stereo audio levels with the useVuMeter Hook.
+---
+
+import { HookApi } from '@/app/_components/hook-api'
+import { HookDemo } from '@/app/_components/hook-demo'
+
+# `useVuMeter`
+
+`useVuMeter` creates a Tone meter graph and exposes live mono or stereo decibel readings for the `VuMeter` component.
+
+[View source](https://github.com/codeacme17/echo-ui/blob/main/packages/hooks/useVuMeter.ts)
+
+## Import
+
+```tsx
+import { VuMeter, useVuMeter, type UseVuMeterProps } from '@nafr/echo-ui'
+```
+
+## Live example
+
+Start the bundled source from a user action, observe its mono level, then stop or switch sources and verify the meter returns to its idle value.
+
+<HookDemo hook="useVuMeter" lang="en" />
+
+<h2 id="parameters">Parameters</h2>
+
+<HookApi hook="useVuMeter" lang="en" section="parameters" />
+
+<h2 id="return-value">Return value</h2>
+
+<HookApi hook="useVuMeter" lang="en" section="returns" />
+
+<h2 id="lifecycle">Lifecycle</h2>
+
+The shape of the initial `value` selects mono or stereo mode. Call `init` once, connect `meter.current` into the player chain, and call `observe` once while active. Call `cancelObserve` before stop or source replacement. On unmount, dispose the source as well as the meter graph.
+
+<h2 id="errors">Errors</h2>
+
+Connecting before `init`, invalid graph nodes, or reads after disposal can set `error` and `errorMessage` and call `onError`. Stop the frame loop and show a retry action when this happens.

--- a/docs-nextra/content/en/hook/useWaveform.mdx
+++ b/docs-nextra/content/en/hook/useWaveform.mdx
@@ -1,0 +1,41 @@
+---
+title: useWaveform
+description: Simplify decoded audio into waveform samples with the useWaveform Hook.
+---
+
+import { HookApi } from '@/app/_components/hook-api'
+import { HookDemo } from '@/app/_components/hook-demo'
+
+# `useWaveform`
+
+`useWaveform` reduces one or two channels from an `AudioBuffer` into a fixed sample count for the `Waveform` component.
+
+[View source](https://github.com/codeacme17/echo-ui/blob/main/packages/hooks/useWaveform.ts)
+
+## Import
+
+```tsx
+import { Waveform, useWaveform, type UseWaveformProps } from '@nafr/echo-ui'
+```
+
+## Live example
+
+Load the bundled buffer and inspect its generated waveform, or switch sources to discard the previous result and exercise recoverable failure feedback.
+
+<HookDemo hook="useWaveform" lang="en" />
+
+<h2 id="parameters">Parameters</h2>
+
+<HookApi hook="useWaveform" lang="en" section="parameters" />
+
+<h2 id="return-value">Return value</h2>
+
+<HookApi hook="useWaveform" lang="en" section="returns" />
+
+<h2 id="lifecycle">Lifecycle</h2>
+
+Pass `null` until decoding completes, then supply the `AudioBuffer`. Recreate the consumer when the source changes so stale samples are not shown. This Hook creates no audio nodes or animation loop; release the code that fetched or plays the buffer separately.
+
+<h2 id="errors">Errors</h2>
+
+Requesting more channels than the buffer contains, an invalid sample count, or buffer access after release can set `error` and `errorMessage`. Validate channel count and keep a source retry action visible.

--- a/docs-nextra/content/zh/_meta.ts
+++ b/docs-nextra/content/zh/_meta.ts
@@ -26,7 +26,7 @@ const meta: MetaRecord = {
     type: 'page',
   },
   hook: {
-    href: '/zh/guide/declaration/#关于-hook',
+    href: '/zh/hook/useFetchAudio/',
     title: 'Hook',
     type: 'page',
   },

--- a/docs-nextra/content/zh/hook/_meta.ts
+++ b/docs-nextra/content/zh/hook/_meta.ts
@@ -1,0 +1,12 @@
+import type { MetaRecord } from 'nextra'
+
+const meta: MetaRecord = {
+  useFetchAudio: 'useFetchAudio',
+  useOscilloscope: 'useOscilloscope',
+  usePlayer: 'usePlayer',
+  useSpectrogram: 'useSpectrogram',
+  useVuMeter: 'useVuMeter',
+  useWaveform: 'useWaveform',
+}
+
+export default meta

--- a/docs-nextra/content/zh/hook/useFetchAudio.mdx
+++ b/docs-nextra/content/zh/hook/useFetchAudio.mdx
@@ -1,0 +1,41 @@
+---
+title: useFetchAudio
+description: 使用 useFetchAudio Hook 请求并解码音频数据。
+---
+
+import { HookApi } from '@/app/_components/hook-api'
+import { HookDemo } from '@/app/_components/hook-demo'
+
+# `useFetchAudio`
+
+`useFetchAudio` 请求音频资源，并将响应解码为 `AudioBuffer`，供播放、分析或波形处理使用。
+
+[查看源码](https://github.com/codeacme17/echo-ui/blob/main/packages/hooks/useFetchAudio.ts)
+
+## 引入
+
+```tsx
+import { useFetchAudio, type UseFetchAudioProps } from '@nafr/echo-ui'
+```
+
+## 实时示例
+
+通过用户操作加载内置音频，或选择不可用的音频源来查看可恢复的错误反馈。
+
+<HookDemo hook="useFetchAudio" lang="zh" />
+
+<h2 id="parameters">传参</h2>
+
+<HookApi hook="useFetchAudio" lang="zh" section="parameters" />
+
+<h2 id="return-value">返回值</h2>
+
+<HookApi hook="useFetchAudio" lang="zh" section="returns" />
+
+<h2 id="lifecycle">生命周期</h2>
+
+当浏览器要求先获得音频启动权限时，应在用户操作中调用 `fetchAudio`。等待 `audioBuffer` 可用后再初始化播放器或分析器。URL 改变时，应先释放上一份缓冲区的使用者，再开始下一次请求。
+
+<h2 id="errors">错误处理</h2>
+
+HTTP 错误与解码错误会设置 `error` 和 `errorMessage`，并调用 `onError`。界面应提供可见的重试操作；跨域地址还必须允许 CORS 请求。

--- a/docs-nextra/content/zh/hook/useOscilloscope.mdx
+++ b/docs-nextra/content/zh/hook/useOscilloscope.mdx
@@ -1,0 +1,41 @@
+---
+title: useOscilloscope
+description: 使用 useOscilloscope Hook 监听实时音频时域数据。
+---
+
+import { HookApi } from '@/app/_components/hook-api'
+import { HookDemo } from '@/app/_components/hook-demo'
+
+# `useOscilloscope`
+
+`useOscilloscope` 创建 Tone 波形分析器，并将每一帧转换为带索引的振幅点，供 `Oscilloscope` 组件使用。
+
+[查看源码](https://github.com/codeacme17/echo-ui/blob/main/packages/hooks/useOscilloscope.ts)
+
+## 引入
+
+```tsx
+import { Oscilloscope, useOscilloscope, type UseOscilloscopeProps } from '@nafr/echo-ui'
+```
+
+## 实时示例
+
+准备内置音频源，通过用户操作开始监听并停止，或切换到不可用的音频源来查看错误反馈。
+
+<HookDemo hook="useOscilloscope" lang="zh" />
+
+<h2 id="parameters">传参</h2>
+
+<HookApi hook="useOscilloscope" lang="zh" section="parameters" />
+
+<h2 id="return-value">返回值</h2>
+
+<HookApi hook="useOscilloscope" lang="zh" section="returns" />
+
+<h2 id="lifecycle">生命周期</h2>
+
+只调用一次 `init`，把 `analyser.current` 接入音频源链，并在播放期间只调用一次 `observer`。停止或切换音频源前调用 `cancelObserve`。Hook 会在卸载时销毁分析器；音频源或播放器也必须由其所有者停止并销毁。
+
+<h2 id="errors">错误处理</h2>
+
+无效的 `fftSize`、不可用的 Web Audio API，或在清理后读取分析器，都可能设置 `error` 和 `errorMessage` 并调用 `onError`。音频源和分析器就绪前应禁用启动操作。

--- a/docs-nextra/content/zh/hook/usePlayer.mdx
+++ b/docs-nextra/content/zh/hook/usePlayer.mdx
@@ -1,0 +1,41 @@
+---
+title: usePlayer
+description: 使用 usePlayer Hook 控制 Tone 播放与进度。
+---
+
+import { HookApi } from '@/app/_components/hook-api'
+import { HookDemo } from '@/app/_components/hook-demo'
+
+# `usePlayer`
+
+`usePlayer` 为已解码的 `AudioBuffer` 管理 Tone Player、播放状态、进度监听、增益、循环与静音控制。
+
+[查看源码](https://github.com/codeacme17/echo-ui/blob/main/packages/hooks/usePlayer.ts)
+
+## 引入
+
+```tsx
+import { usePlayer, type UsePlayerProps } from '@nafr/echo-ui'
+```
+
+## 实时示例
+
+加载内置缓冲区，通过用户操作启动音频上下文并监听进度，然后停止或切换音频源，确保没有遗留播放与动画任务。
+
+<HookDemo hook="usePlayer" lang="zh" />
+
+<h2 id="parameters">传参</h2>
+
+<HookApi hook="usePlayer" lang="zh" section="parameters" />
+
+<h2 id="return-value">返回值</h2>
+
+<HookApi hook="usePlayer" lang="zh" section="returns" />
+
+<h2 id="lifecycle">生命周期</h2>
+
+先请求并解码音频源，再调用 `init`。通过点击或键盘操作恢复浏览器音频上下文；播放时只调用一次 `observe`，并与 `cancelObserve` 配对。切换音频源或卸载前，停止播放、取消监听，并让 Hook 销毁 Player。不要在 `chain` 末尾加入 `Tone.Destination`，`init` 会自动完成连接。
+
+<h2 id="errors">错误处理</h2>
+
+在 `init` 前播放、无效的偏移量、浏览器未授予音频启动权限，或无效的链节点都可能失败。Hook 会提供 `error` 与 `errorMessage` 并调用 `onError`；可恢复时应保留重试与停止操作。

--- a/docs-nextra/content/zh/hook/useSpectrogram.mdx
+++ b/docs-nextra/content/zh/hook/useSpectrogram.mdx
@@ -1,0 +1,41 @@
+---
+title: useSpectrogram
+description: 使用 useSpectrogram Hook 监听实时 FFT 数据。
+---
+
+import { HookApi } from '@/app/_components/hook-api'
+import { HookDemo } from '@/app/_components/hook-demo'
+
+# `useSpectrogram`
+
+`useSpectrogram` 创建 Tone FFT 分析器，并将频率分箱格式化后交给 `Spectrogram` 组件。
+
+[查看源码](https://github.com/codeacme17/echo-ui/blob/main/packages/hooks/useSpectrogram.ts)
+
+## 引入
+
+```tsx
+import { Spectrogram, useSpectrogram, type UseSpectrogramProps } from '@nafr/echo-ui'
+```
+
+## 实时示例
+
+准备并启动内置音频源，停止 FFT 监听，或切换音频源来验证清理与错误反馈。
+
+<HookDemo hook="useSpectrogram" lang="zh" />
+
+<h2 id="parameters">传参</h2>
+
+<HookApi hook="useSpectrogram" lang="zh" section="parameters" />
+
+<h2 id="return-value">返回值</h2>
+
+<HookApi hook="useSpectrogram" lang="zh" section="returns" />
+
+<h2 id="lifecycle">生命周期</h2>
+
+只调用一次 `init`，把 `analyser.current` 接入音频源链，并在播放时只调用一次 `observe`。停止、更换音频源或手动清理前调用 `cancelObserve`。分析器会在卸载时销毁，音频源仍由其所有者负责清理。
+
+<h2 id="errors">错误处理</h2>
+
+不是 2 的幂的 `fftSize`、不受支持的 Web Audio，或读取已销毁的分析器，都可能设置 `error` 与 `errorMessage`。此时应保持可视化为空，显示重试操作，而不是继续动画循环。

--- a/docs-nextra/content/zh/hook/useVuMeter.mdx
+++ b/docs-nextra/content/zh/hook/useVuMeter.mdx
@@ -1,0 +1,41 @@
+---
+title: useVuMeter
+description: 使用 useVuMeter Hook 监听单声道或立体声音频电平。
+---
+
+import { HookApi } from '@/app/_components/hook-api'
+import { HookDemo } from '@/app/_components/hook-demo'
+
+# `useVuMeter`
+
+`useVuMeter` 创建 Tone 电平图，并为 `VuMeter` 组件提供实时单声道或立体声分贝读数。
+
+[查看源码](https://github.com/codeacme17/echo-ui/blob/main/packages/hooks/useVuMeter.ts)
+
+## 引入
+
+```tsx
+import { VuMeter, useVuMeter, type UseVuMeterProps } from '@nafr/echo-ui'
+```
+
+## 实时示例
+
+通过用户操作启动内置音频源并监听单声道电平，然后停止或切换音频源，确认电平表恢复为空闲值。
+
+<HookDemo hook="useVuMeter" lang="zh" />
+
+<h2 id="parameters">传参</h2>
+
+<HookApi hook="useVuMeter" lang="zh" section="parameters" />
+
+<h2 id="return-value">返回值</h2>
+
+<HookApi hook="useVuMeter" lang="zh" section="returns" />
+
+<h2 id="lifecycle">生命周期</h2>
+
+初始 `value` 的形状决定单声道或立体声模式。只调用一次 `init`，将 `meter.current` 接入播放器链，并在活动期间只调用一次 `observe`。停止或更换音频源前调用 `cancelObserve`。卸载时应同时销毁音频源与电平图。
+
+<h2 id="errors">错误处理</h2>
+
+在 `init` 前连接、无效的音频图节点，或销毁后继续读取，都可能设置 `error` 与 `errorMessage` 并调用 `onError`。发生错误时停止动画帧循环，并显示重试操作。

--- a/docs-nextra/content/zh/hook/useWaveform.mdx
+++ b/docs-nextra/content/zh/hook/useWaveform.mdx
@@ -1,0 +1,41 @@
+---
+title: useWaveform
+description: 使用 useWaveform Hook 将解码音频简化为波形采样。
+---
+
+import { HookApi } from '@/app/_components/hook-api'
+import { HookDemo } from '@/app/_components/hook-demo'
+
+# `useWaveform`
+
+`useWaveform` 将 `AudioBuffer` 中的一到两个声道缩减为固定数量的采样，供 `Waveform` 组件使用。
+
+[查看源码](https://github.com/codeacme17/echo-ui/blob/main/packages/hooks/useWaveform.ts)
+
+## 引入
+
+```tsx
+import { Waveform, useWaveform, type UseWaveformProps } from '@nafr/echo-ui'
+```
+
+## 实时示例
+
+加载内置缓冲区并查看生成的波形，或切换音频源来丢弃旧结果并查看可恢复的错误反馈。
+
+<HookDemo hook="useWaveform" lang="zh" />
+
+<h2 id="parameters">传参</h2>
+
+<HookApi hook="useWaveform" lang="zh" section="parameters" />
+
+<h2 id="return-value">返回值</h2>
+
+<HookApi hook="useWaveform" lang="zh" section="returns" />
+
+<h2 id="lifecycle">生命周期</h2>
+
+解码完成前传入 `null`，然后再提供 `AudioBuffer`。音频源变化时应重新创建使用者，避免显示旧采样。此 Hook 不会创建音频节点或动画循环；请求或播放缓冲区的代码仍需单独释放资源。
+
+<h2 id="errors">错误处理</h2>
+
+请求超过缓冲区实际数量的声道、无效的采样数量，或释放后访问缓冲区，都可能设置 `error` 与 `errorMessage`。应验证声道数量并保留音频源重试操作。

--- a/docs-nextra/hook-manifest.mjs
+++ b/docs-nextra/hook-manifest.mjs
@@ -1,0 +1,8 @@
+export const hookNames = /** @type {const} */ ([
+  'useFetchAudio',
+  'useOscilloscope',
+  'usePlayer',
+  'useSpectrogram',
+  'useVuMeter',
+  'useWaveform',
+])

--- a/packages/hooks/usePlayer.ts
+++ b/packages/hooks/usePlayer.ts
@@ -92,6 +92,10 @@ export const usePlayer = (props: UsePlayerProps = {}) => {
 
   useEffect(() => {
     return () => {
+      if (observeId.current) {
+        cancelAnimationFrame(observeId.current)
+        observeId.current = 0
+      }
       if (!player.current) return
       player.current.stop()
       player.current.dispose()
@@ -254,11 +258,11 @@ export const usePlayer = (props: UsePlayerProps = {}) => {
   }, [getTime, error])
 
   const cancelObserve = () => {
-    if (!player.current || error) return
     if (!observeId.current) return
 
     try {
       cancelAnimationFrame(observeId.current)
+      observeId.current = 0
     } catch (err) {
       setError(true)
       setErrorMessage(err as string)

--- a/packages/hooks/useSpectrogram.ts
+++ b/packages/hooks/useSpectrogram.ts
@@ -30,7 +30,7 @@ const FFT_SIZE = 1024
  * - errorMessage: A string containing the error message if an error has occurred.
  */
 export const useSpectrogram = (props: UseSpectrogramProps = {}) => {
-  const { fftSize = FFT_SIZE } = props
+  const { fftSize = FFT_SIZE, onReady, onError } = props
 
   const analyser = useRef<Tone.Analyser | null>(null)
   const observerId = useRef<number>(0)
@@ -43,7 +43,8 @@ export const useSpectrogram = (props: UseSpectrogramProps = {}) => {
     setError(true)
     setErrorMessage(err as string)
     logger.error(err as string)
-  }, [])
+    onError?.()
+  }, [onError])
 
   useEffect(() => {
     return () => {
@@ -65,10 +66,11 @@ export const useSpectrogram = (props: UseSpectrogramProps = {}) => {
   const init = useCallback(() => {
     try {
       analyser.current = new Tone.Analyser('fft', fftSize)
+      onReady?.()
     } catch (err) {
       handleError(err)
     }
-  }, [fftSize, handleError])
+  }, [fftSize, handleError, onReady])
 
   const getData = useCallback(() => {
     if (!analyser.current || error) return

--- a/scripts/smoke-nextra-routes.mjs
+++ b/scripts/smoke-nextra-routes.mjs
@@ -5,6 +5,7 @@ import { createServer } from 'node:http'
 import { dirname, extname, resolve, sep } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { chromium } from '@playwright/test'
+import { hookNames } from '../docs-nextra/hook-manifest.mjs'
 
 const repositoryRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..')
 const outputRoot = resolve(repositoryRoot, 'docs-nextra', 'out')
@@ -20,10 +21,13 @@ const allControllers = [
   'switch',
 ]
 const allDisplays = ['lfo', 'light', 'oscilloscope', 'spectrogram', 'vumeter', 'waveform', 'card']
+const allHooks = hookNames
 const selectedDisplay = process.env.SMOKE_DISPLAY
+const selectedHook = process.env.SMOKE_HOOK
 const selectedLocale = process.env.SMOKE_LOCALE
-const controllers = selectedDisplay ? [] : allControllers
-const displays = selectedDisplay ? [selectedDisplay] : allDisplays
+const controllers = selectedDisplay || selectedHook ? [] : allControllers
+const displays = selectedHook ? [] : selectedDisplay ? [selectedDisplay] : allDisplays
+const hooks = selectedDisplay ? [] : selectedHook ? [selectedHook] : allHooks
 const locales = selectedLocale ? [selectedLocale] : ['en', 'zh']
 
 assert.ok(
@@ -31,6 +35,7 @@ assert.ok(
   'SMOKE_DISPLAY must name a display',
 )
 assert.ok(!selectedLocale || ['en', 'zh'].includes(selectedLocale), 'SMOKE_LOCALE must be en or zh')
+assert.ok(!selectedHook || allHooks.includes(selectedHook), 'SMOKE_HOOK must name a Hook')
 
 assert.ok(!basePath || (basePath.startsWith('/') && !basePath.endsWith('/')))
 
@@ -214,6 +219,87 @@ const exerciseDisplay = async (page, display, locale) => {
   assert.equal(await demo.getAttribute('data-graph-connected'), 'false')
 }
 
+const waitForHookState = (page, hook, state) =>
+  page.waitForFunction(
+    ({ hookName, expectedState }) =>
+      document
+        .querySelector(`[data-hook-demo="${hookName}"]`)
+        ?.getAttribute('data-audio-state') === expectedState,
+    { hookName: hook, expectedState: state },
+    { timeout: 10_000 },
+  )
+
+const exerciseHook = async (page, hook, locale) => {
+  const demo = page.locator(`[data-hook-demo="${hook}"]`)
+  const runsActiveGraph = ['useOscilloscope', 'usePlayer', 'useSpectrogram', 'useVuMeter'].includes(
+    hook,
+  )
+  const labels =
+    locale === 'zh'
+      ? {
+          load: hook === 'useWaveform' ? '生成波形' : '加载音频',
+          fail: '模拟音频图故障',
+          prepare: '准备音频',
+          source: '音频源',
+          start: '开始',
+          stop: '停止并释放',
+          unavailable: '不可用的音频源',
+        }
+      : {
+          load: hook === 'useWaveform' ? 'Generate waveform' : 'Load audio',
+          fail: 'Simulate graph failure',
+          prepare: 'Prepare audio',
+          source: 'Audio source',
+          start: 'Start',
+          stop: 'Stop and release',
+          unavailable: 'Unavailable source',
+        }
+
+  if (runsActiveGraph) {
+    await demo.getByRole('button', { name: labels.prepare }).click()
+    await waitForHookState(page, hook, 'ready')
+    await demo.getByRole('button', { name: labels.start }).click()
+    await waitForHookState(page, hook, 'playing')
+    assert.equal(await demo.getAttribute('data-animation-active'), 'true')
+    assert.equal(await demo.getAttribute('data-graph-connected'), 'true')
+    assert.ok(Number(await demo.getAttribute('data-connection-count')) >= 1)
+
+    await demo.getByRole('button', { name: labels.fail }).click()
+    await waitForHookState(page, hook, 'error')
+    assert.equal(await demo.getAttribute('data-animation-active'), 'false')
+    assert.equal(await demo.getAttribute('data-graph-connected'), 'false')
+
+    await demo.getByRole('button', { name: labels.prepare }).click()
+    await waitForHookState(page, hook, 'ready')
+    await demo.getByRole('button', { name: labels.start }).click()
+    await waitForHookState(page, hook, 'playing')
+    await demo.getByRole('button', { name: labels.stop }).click()
+    await waitForHookState(page, hook, 'stopped')
+    assert.equal(await demo.getAttribute('data-animation-active'), 'false')
+    assert.equal(await demo.getAttribute('data-graph-connected'), 'false')
+
+    await demo.getByRole('button', { name: labels.prepare }).click()
+    await waitForHookState(page, hook, 'ready')
+    await demo.getByRole('button', { name: labels.start }).click()
+    await waitForHookState(page, hook, 'playing')
+  } else {
+    await demo.getByRole('button', { name: labels.load }).click()
+    await waitForHookState(page, hook, 'ready')
+    assert.equal(await demo.getAttribute('data-animation-active'), 'false')
+    assert.equal(await demo.getAttribute('data-graph-connected'), 'false')
+  }
+
+  await demo.getByLabel(labels.source).selectOption('unavailable')
+  await waitForHookState(page, hook, 'idle')
+  assert.equal(await demo.getAttribute('data-animation-active'), 'false')
+  assert.equal(await demo.getAttribute('data-graph-connected'), 'false')
+  await demo.getByRole('button', { name: runsActiveGraph ? labels.prepare : labels.load }).click()
+  await waitForHookState(page, hook, 'error')
+  await demo.getByRole('alert').filter({ hasText: labels.unavailable }).waitFor({ state: 'visible' })
+  assert.equal(await demo.getAttribute('data-animation-active'), 'false')
+  assert.equal(await demo.getAttribute('data-graph-connected'), 'false')
+}
+
 const address = await listen()
 assert.ok(address && typeof address === 'object')
 
@@ -223,7 +309,13 @@ let browser
 try {
   browser = await launchBrowser()
 
-  const runComponentRoute = async ({ apiSelector, demoSelector, exercise, route }) => {
+  const runComponentRoute = async ({
+    allowedBrowserErrors = [],
+    apiSelector,
+    demoSelector,
+    exercise,
+    route,
+  }) => {
     console.log(`Smoke: ${route}`)
     const page = await browser.newPage()
     const browserErrors = []
@@ -237,9 +329,16 @@ try {
       const response = await page.goto(`${origin}${route}`, { waitUntil: 'networkidle' })
       assert.ok(response?.ok(), `${route} should return a successful browser response`)
       await page.locator(demoSelector).waitFor({ state: 'visible' })
-      await page.locator(apiSelector).waitFor({ state: 'visible' })
+      await page.locator(apiSelector).first().waitFor({ state: 'visible' })
       await exercise(page)
-      assert.deepEqual(browserErrors, [], `${route} should hydrate without browser errors`)
+      const unexpectedBrowserErrors = browserErrors.filter(
+        (message) => !allowedBrowserErrors.some((pattern) => pattern.test(message)),
+      )
+      assert.deepEqual(
+        unexpectedBrowserErrors,
+        [],
+        `${route} should hydrate without unexpected browser errors`,
+      )
     } finally {
       await page.close()
     }
@@ -265,12 +364,24 @@ try {
         route,
       })
     }
+
+    for (const hook of hooks) {
+      const route = `${basePath}/${locale}/hook/${hook}/`
+      await runComponentRoute({
+        allowedBrowserErrors: [
+          /^Echo UI: Error: Not Found/,
+          /^Failed to load resource: the server responded with a status of 404/,
+        ],
+        apiSelector: `[data-hook-api="${hook}"]`,
+        demoSelector: `[data-hook-demo="${hook}"]`,
+        exercise: (page) => exerciseHook(page, hook, locale),
+        route,
+      })
+    }
   }
 } finally {
   await browser?.close()
   await closeServer()
 }
 
-console.log(
-  'Nextra browser smoke exercised all bilingual component routes and audio lifecycle controls.',
-)
+console.log('Nextra browser smoke exercised bilingual components, Hooks, and audio lifecycle controls.')

--- a/scripts/verify-nextra-output.mjs
+++ b/scripts/verify-nextra-output.mjs
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict'
 import { access, readFile, readdir } from 'node:fs/promises'
 import { dirname, extname, join, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
+import { hookNames } from '../docs-nextra/hook-manifest.mjs'
 
 const repositoryRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..')
 const nextraRoot = resolve(repositoryRoot, 'docs-nextra')
@@ -136,6 +137,7 @@ const locales = {
     componentLabel: 'Component',
     footer: 'Released under the MIT License.',
     guideLabel: 'Guide',
+    hookLabel: 'Hook',
     tocLabel: 'On this page',
   },
   zh: {
@@ -143,12 +145,14 @@ const locales = {
     componentLabel: '组件',
     footer: '基于 MIT 许可证发布。',
     guideLabel: '指南',
+    hookLabel: 'Hook',
     tocLabel: '本页目录',
   },
 }
 
 const controllers = ['button', 'checkbox', 'envelope', 'input', 'knob', 'radio', 'slider', 'switch']
 const displays = ['lfo', 'light', 'oscilloscope', 'spectrogram', 'vumeter', 'waveform', 'card']
+const hooks = hookNames
 
 for (const page of pages) {
   for (const [locale, labels] of Object.entries(locales)) {
@@ -272,6 +276,43 @@ for (const [locale, labels] of Object.entries(locales)) {
   }
 }
 
+const verifyHookRoute = async ({ hook, labels, locale }) => {
+  const html = await readFile(resolve(outputRoot, locale, 'hook', hook, 'index.html'), 'utf8')
+  const localizedRoute = `/${locale}/hook/${hook}/`
+
+  assert.match(html, new RegExp(`<html[^>]+lang="${locale}"`))
+  assert.ok(html.includes(`<h1`), `${localizedRoute} should include its heading`)
+  assert.ok(
+    html.includes(`data-hook-api="${hook}"`),
+    `${localizedRoute} should render its public Hook contract`,
+  )
+  for (const sectionId of ['parameters', 'return-value', 'lifecycle', 'errors']) {
+    assert.ok(
+      html.includes(`id="${sectionId}"`),
+      `${localizedRoute} should document ${sectionId}`,
+    )
+  }
+  assert.ok(
+    html.includes(`packages/hooks/${hook}.ts`),
+    `${localizedRoute} should link to the Hook source`,
+  )
+  assert.ok(
+    html.includes(`href="${withBasePath(localizedRoute)}"`),
+    `${localizedRoute} navigation should expose the localized Hook route`,
+  )
+  assert.ok(html.includes(labels.hookLabel), `${localizedRoute} should label Hook navigation`)
+  assert.ok(html.includes('title="Change theme"'), `${localizedRoute} should switch themes`)
+  assert.ok(html.includes('title="Change language"'), `${localizedRoute} should switch locales`)
+  assert.ok(html.includes(labels.tocLabel), `${localizedRoute} should label its table of contents`)
+  assert.ok(html.includes(labels.footer), `${localizedRoute} should include a localized footer`)
+  await access(resolve(outputRoot, labels.counterpart, 'hook', hook, 'index.html'))
+  await assertInternalLinksResolve(html, localizedRoute)
+}
+
+for (const [locale, labels] of Object.entries(locales)) {
+  for (const hook of hooks) await verifyHookRoute({ hook, labels, locale })
+}
+
 for (const sourceRoot of [resolve(nextraRoot, 'app'), resolve(nextraRoot, 'content')]) {
   const sourceFiles = (await readdir(sourceRoot, { recursive: true }))
     .filter((file) => /\.(?:mdx|ts|tsx)$/.test(file))
@@ -290,5 +331,5 @@ const css = (
 assert.ok(css.includes('--echo-primary'), 'static CSS should include Echo UI styles')
 
 console.log(
-  'Nextra static output exposes bilingual guides, component routes, API references, and live Echo UI demos.',
+  'Nextra static output exposes bilingual guides, components, Hooks, API references, and live Echo UI demos.',
 )

--- a/tests/usePlayer.test.tsx
+++ b/tests/usePlayer.test.tsx
@@ -1,0 +1,80 @@
+import { act, cleanup, renderHook, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { usePlayer } from '../packages/hooks/usePlayer'
+
+const tone = vi.hoisted(() => ({ Destination: {}, Player: vi.fn() }))
+
+vi.mock('tone', () => tone)
+
+let playerNode: {
+  chain: ReturnType<typeof vi.fn>
+  dispose: ReturnType<typeof vi.fn>
+  immediate: ReturnType<typeof vi.fn>
+  loop: boolean
+  mute: boolean
+  start: ReturnType<typeof vi.fn>
+  state: string
+  stop: ReturnType<typeof vi.fn>
+  toDestination: ReturnType<typeof vi.fn>
+  volume: { value: number }
+}
+
+beforeEach(() => {
+  playerNode = {
+    chain: vi.fn(),
+    dispose: vi.fn(),
+    immediate: vi.fn(() => 1),
+    loop: false,
+    mute: false,
+    start: vi.fn(),
+    state: 'stopped',
+    stop: vi.fn(),
+    toDestination: vi.fn(),
+    volume: { value: 0 },
+  }
+  tone.Player.mockImplementation(function Player() {
+    return playerNode
+  })
+  vi.stubGlobal('requestAnimationFrame', vi.fn(() => 42))
+  vi.stubGlobal('cancelAnimationFrame', vi.fn())
+})
+
+afterEach(() => {
+  cleanup()
+  vi.clearAllMocks()
+  vi.unstubAllGlobals()
+})
+
+describe('usePlayer', () => {
+  it('can cancel progress observation after playback reports an error', async () => {
+    const { result } = renderHook(() => usePlayer())
+    playerNode.start.mockImplementationOnce(() => {
+      throw new Error('playback failed')
+    })
+
+    act(() => {
+      result.current.init({ duration: 10 } as AudioBuffer)
+      result.current.observe()
+      result.current.play()
+    })
+
+    await waitFor(() => expect(result.current.error).toBe(true))
+    act(() => result.current.cancelObserve())
+
+    expect(cancelAnimationFrame).toHaveBeenCalledWith(42)
+  })
+
+  it('cancels progress observation when its component unmounts', () => {
+    const { result, unmount } = renderHook(() => usePlayer())
+
+    act(() => {
+      result.current.init({ duration: 10 } as AudioBuffer)
+      result.current.observe()
+    })
+    unmount()
+
+    expect(cancelAnimationFrame).toHaveBeenCalledWith(42)
+    expect(playerNode.stop).toHaveBeenCalledOnce()
+    expect(playerNode.dispose).toHaveBeenCalledOnce()
+  })
+})

--- a/tests/useSpectrogram.test.tsx
+++ b/tests/useSpectrogram.test.tsx
@@ -1,0 +1,45 @@
+import { act, cleanup, renderHook } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { useSpectrogram } from '../packages/hooks/useSpectrogram'
+
+const tone = vi.hoisted(() => ({ Analyser: vi.fn() }))
+
+vi.mock('tone', () => ({ Analyser: tone.Analyser }))
+
+beforeEach(() => {
+  tone.Analyser.mockImplementation(function Analyser() {
+    return {
+      dispose: vi.fn(),
+      getValue: vi.fn(() => new Float32Array()),
+      size: 1024,
+    }
+  })
+})
+
+afterEach(() => {
+  cleanup()
+  vi.clearAllMocks()
+})
+
+describe('useSpectrogram', () => {
+  it('notifies callers when the analyser is ready', () => {
+    const onReady = vi.fn()
+    const { result } = renderHook(() => useSpectrogram({ onReady }))
+
+    act(() => result.current.init())
+
+    expect(onReady).toHaveBeenCalledOnce()
+  })
+
+  it('notifies callers when analyser initialization fails', () => {
+    const onError = vi.fn()
+    tone.Analyser.mockImplementationOnce(function Analyser() {
+      throw new Error('invalid fft size')
+    })
+    const { result } = renderHook(() => useSpectrogram({ onError }))
+
+    act(() => result.current.init())
+
+    expect(onError).toHaveBeenCalledOnce()
+  })
+})


### PR DESCRIPTION
## Summary

- migrate the six Hook guides to bilingual Nextra routes
- add live examples covering browser startup, source switching, runtime failures, stop, and cleanup
- align usePlayer and useSpectrogram lifecycle callbacks with the documented contracts
- add shared Hook metadata plus static, browser-smoke, and unit coverage

## Verification

- pnpm lint
- pnpm verify
- Nextra base-path build and browser smoke
- standards and issue-spec reviews completed with no remaining findings

Closes #83