### PR TITLE
feat: migrate audio hooks and examples to Tone.js 15

### DIFF
--- a/docs/app/_components/hook-api.tsx
+++ b/docs/app/_components/hook-api.tsx
@@ -401,11 +401,11 @@ const definitions: Record<HookName, HookApiDefinition> = {
           name: 'init',
           type: '() => void',
           defaultValue: '—',
-          description: text('Creates a mono meter or stereo split graph.', '创建单声道电平表或立体声分离图。'),
+          description: text('Creates a one- or two-channel Tone 15 meter.', '创建单声道或双声道 Tone 15 电平表。'),
         },
         {
           name: 'meter',
-          type: 'MutableRefObject<Tone.Meter | Tone.Split | null>',
+          type: 'MutableRefObject<Tone.Meter | null>',
           defaultValue: 'null',
           description: text('Node to connect to the source chain.', '连接到音频源链的节点。'),
         },

--- a/docs/content/en/guide/declaration.mdx
+++ b/docs/content/en/guide/declaration.mdx
@@ -13,7 +13,9 @@ Use Echo UI alongside a broader component system when an application needs both 
 
 ## About the hooks
 
-Many Echo UI hooks wrap concepts from [Tone.js](https://tonejs.github.io/). Reading the Tone.js documentation first will make their timing, transport, and audio-node behavior easier to understand. Components can also be connected to another audio library or directly to the native Web Audio API.
+Echo UI `1.1.x` uses and tests against Tone.js `15.1.22`. Tone remains a direct runtime dependency because public Hook declarations expose types such as `Tone.Player`, `Tone.Analyser`, and `Tone.InputNode`. The ESM and UMD library bundles externalize Tone instead of embedding a second copy, so an installed consumer resolves one compatible Tone 15 runtime and one Web Audio context/class identity.
+
+Applications normally do not need to install Tone separately. If an application imports Tone directly, keep it on `^15.1.22` so the package manager can deduplicate it. Script-tag consumers of the UMD build must provide the Tone global alongside React. Reading the [Tone.js documentation](https://tonejs.github.io/) first will make Hook timing and audio-node behavior easier to understand. Presentational components can still be connected to another audio library or directly to the native Web Audio API.
 
 ## About this documentation
 

--- a/docs/content/en/hook/useFetchAudio.mdx
+++ b/docs/content/en/hook/useFetchAudio.mdx
@@ -34,7 +34,7 @@ Load the bundled audio from a user action, or choose the unavailable source to s
 
 <h2 id="lifecycle">Lifecycle</h2>
 
-Call `fetchAudio` from a user action when the browser requires audio startup permission. Wait for `audioBuffer` before initializing players or analysers. When the URL changes, release consumers of the previous buffer before starting the next request.
+Call `fetchAudio` from a user action when the browser requires audio startup permission. Wait for `audioBuffer` before initializing players or analysers. A new request aborts the previous one, the temporary decoding `AudioContext` closes after decoding, and unmounting aborts in-flight work. Release consumers of the previous buffer before switching sources.
 
 <h2 id="errors">Errors</h2>
 

--- a/docs/content/en/hook/usePlayer.mdx
+++ b/docs/content/en/hook/usePlayer.mdx
@@ -34,7 +34,7 @@ Load the bundled buffer, start the audio context from a user action, observe pro
 
 <h2 id="lifecycle">Lifecycle</h2>
 
-Fetch and decode the source before calling `init`. Resume the browser audio context from a click or key action, call `observe` only once while playing, and pair it with `cancelObserve`. Before switching sources or unmounting, stop playback, cancel observation, and let the Hook dispose its Player. Do not append `Tone.Destination` to `chain`; `init` does that for you.
+Fetch and decode the source before calling `init`. Resume the browser audio context from a click or key action, call `observe` only once while playing, and pair it with `cancelObserve`. Calling `init` again stops and disposes the previous Player, resets progress, and connects the new source. Unmounting performs the same release automatically. Do not append `Tone.Destination` to `chain`; `init` does that for you.
 
 <h2 id="errors">Errors</h2>
 

--- a/docs/content/en/hook/useVuMeter.mdx
+++ b/docs/content/en/hook/useVuMeter.mdx
@@ -34,7 +34,7 @@ Start the bundled source from a user action, observe its mono level, then stop o
 
 <h2 id="lifecycle">Lifecycle</h2>
 
-The shape of the initial `value` selects mono or stereo mode. Call `init` once, connect `meter.current` into the player chain, and call `observe` once while active. Call `cancelObserve` before stop or source replacement. On unmount, dispose the source as well as the meter graph.
+The shape of the initial `value` selects mono or stereo mode. `init` creates one Tone 15 `Meter` with one or two analysis channels, and `getValue` normalizes its current `number | number[]` result to match that mode. Connect `meter.current` into the player chain and call `observe` once while active. Call `cancelObserve` before stop or source replacement. On unmount, dispose the source; the Hook cancels its frame loop and disposes the meter.
 
 <h2 id="errors">Errors</h2>
 

--- a/docs/content/en/hook/useWaveform.mdx
+++ b/docs/content/en/hook/useWaveform.mdx
@@ -34,8 +34,8 @@ Load the bundled buffer and inspect its generated waveform, or switch sources to
 
 <h2 id="lifecycle">Lifecycle</h2>
 
-Pass `null` until decoding completes, then supply the `AudioBuffer`. Recreate the consumer when the source changes so stale samples are not shown. This Hook creates no audio nodes or animation loop; release the code that fetched or plays the buffer separately.
+Pass `null` until decoding completes, then supply the `AudioBuffer`. The Hook recomputes when the source, requested channel count, or sample count changes; requesting stereo from a mono buffer uses the available channel without producing invalid samples. This Hook creates no audio nodes or animation loop; release the code that fetched or plays the buffer separately.
 
 <h2 id="errors">Errors</h2>
 
-Requesting more channels than the buffer contains, an invalid sample count, or buffer access after release can set `error` and `errorMessage`. Validate channel count and keep a source retry action visible.
+Invalid buffer access can set `error` and `errorMessage`. Keep a source retry action visible when decoding or a released buffer cannot be read.

--- a/docs/content/zh/guide/declaration.mdx
+++ b/docs/content/zh/guide/declaration.mdx
@@ -13,7 +13,9 @@ description: 了解 Echo UI 组件、Hook 和文档的设计边界。
 
 ## 关于 Hook
 
-Echo UI 的许多 Hook 封装了 [Tone.js](https://tonejs.github.io/) 概念。事先阅读 Tone.js 文档，可以更容易理解时序、Transport 和音频节点的行为。组件也可以接入其他音频库，或直接使用原生 Web Audio API。
+Echo UI `1.1.x` 使用并测试 Tone.js `15.1.22`。Tone 保持为直接运行时依赖，因为公开 Hook 声明会暴露 `Tone.Player`、`Tone.Analyser` 与 `Tone.InputNode` 等类型。ESM 与 UMD 构建会将 Tone 外部化，而不会内嵌第二份副本，因此已安装的消费者会解析到同一个兼容的 Tone 15 运行时，并共享一致的 Web Audio 上下文与类标识。
+
+应用通常无需单独安装 Tone。若应用会直接引入 Tone，请保持使用 `^15.1.22`，以便包管理器完成去重。通过 script 标签使用 UMD 构建时，需要像 React 一样同时提供 Tone 全局变量。事先阅读 [Tone.js 文档](https://tonejs.github.io/)，可以更容易理解 Hook 的时序与音频节点行为。纯展示组件仍可接入其他音频库，或直接使用原生 Web Audio API。
 
 ## 关于本文档
 

--- a/docs/content/zh/hook/useFetchAudio.mdx
+++ b/docs/content/zh/hook/useFetchAudio.mdx
@@ -34,7 +34,7 @@ import { useFetchAudio, type UseFetchAudioProps } from '@nafr/echo-ui'
 
 <h2 id="lifecycle">生命周期</h2>
 
-当浏览器要求先获得音频启动权限时，应在用户操作中调用 `fetchAudio`。等待 `audioBuffer` 可用后再初始化播放器或分析器。URL 改变时，应先释放上一份缓冲区的使用者，再开始下一次请求。
+当浏览器要求先获得音频启动权限时，应在用户操作中调用 `fetchAudio`。等待 `audioBuffer` 可用后再初始化播放器或分析器。新请求会中止旧请求，临时解码 `AudioContext` 会在解码后关闭，卸载时也会中止进行中的工作。切换音频源前仍应释放上一份缓冲区的使用者。
 
 <h2 id="errors">错误处理</h2>
 

--- a/docs/content/zh/hook/usePlayer.mdx
+++ b/docs/content/zh/hook/usePlayer.mdx
@@ -34,7 +34,7 @@ import { usePlayer, type UsePlayerProps } from '@nafr/echo-ui'
 
 <h2 id="lifecycle">生命周期</h2>
 
-先请求并解码音频源，再调用 `init`。通过点击或键盘操作恢复浏览器音频上下文；播放时只调用一次 `observe`，并与 `cancelObserve` 配对。切换音频源或卸载前，停止播放、取消监听，并让 Hook 销毁 Player。不要在 `chain` 末尾加入 `Tone.Destination`，`init` 会自动完成连接。
+先请求并解码音频源，再调用 `init`。通过点击或键盘操作恢复浏览器音频上下文；播放时只调用一次 `observe`，并与 `cancelObserve` 配对。再次调用 `init` 会停止并销毁旧 Player、重置进度，然后连接新音频源；卸载时也会自动执行同样的释放。不要在 `chain` 末尾加入 `Tone.Destination`，`init` 会自动完成连接。
 
 <h2 id="errors">错误处理</h2>
 

--- a/docs/content/zh/hook/useVuMeter.mdx
+++ b/docs/content/zh/hook/useVuMeter.mdx
@@ -34,7 +34,7 @@ import { VuMeter, useVuMeter, type UseVuMeterProps } from '@nafr/echo-ui'
 
 <h2 id="lifecycle">生命周期</h2>
 
-初始 `value` 的形状决定单声道或立体声模式。只调用一次 `init`，将 `meter.current` 接入播放器链，并在活动期间只调用一次 `observe`。停止或更换音频源前调用 `cancelObserve`。卸载时应同时销毁音频源与电平图。
+初始 `value` 的形状决定单声道或立体声模式。`init` 会创建一个包含单声道或双声道分析通道的 Tone 15 `Meter`，`getValue` 则将其当前的 `number | number[]` 返回值规范为对应模式。将 `meter.current` 接入播放器链，并在活动期间只调用一次 `observe`。停止或更换音频源前调用 `cancelObserve`。卸载时应销毁音频源；Hook 会取消动画帧循环并销毁电平表。
 
 <h2 id="errors">错误处理</h2>
 

--- a/docs/content/zh/hook/useWaveform.mdx
+++ b/docs/content/zh/hook/useWaveform.mdx
@@ -34,8 +34,8 @@ import { Waveform, useWaveform, type UseWaveformProps } from '@nafr/echo-ui'
 
 <h2 id="lifecycle">生命周期</h2>
 
-解码完成前传入 `null`，然后再提供 `AudioBuffer`。音频源变化时应重新创建使用者，避免显示旧采样。此 Hook 不会创建音频节点或动画循环；请求或播放缓冲区的代码仍需单独释放资源。
+解码完成前传入 `null`，然后再提供 `AudioBuffer`。音频源、请求声道数或采样数变化时，Hook 会重新计算；对单声道缓冲区请求立体声时会使用现有声道，不会产生无效采样。此 Hook 不会创建音频节点或动画循环；请求或播放缓冲区的代码仍需单独释放资源。
 
 <h2 id="errors">错误处理</h2>
 
-请求超过缓冲区实际数量的声道、无效的采样数量，或释放后访问缓冲区，都可能设置 `error` 与 `errorMessage`。应验证声道数量并保留音频源重试操作。
+无法读取无效或已释放的缓冲区时，Hook 可能设置 `error` 与 `errorMessage`。解码失败或缓冲区不可读时，应保留音频源重试操作。

--- a/example/package.json
+++ b/example/package.json
@@ -15,7 +15,7 @@
     "lucide-react": "^0.468.0",
     "react": "19.2.8",
     "react-dom": "19.2.8",
-    "tone": "^14.7.77"
+    "tone": "^15.1.22"
   },
   "devDependencies": {
     "@tailwindcss/vite": "4.3.3",

--- a/example/src/components/controls/EchoEnvelop.tsx
+++ b/example/src/components/controls/EchoEnvelop.tsx
@@ -1,74 +1,113 @@
 import * as Tone from 'tone'
-import { useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { Envelope, EnvelopeData, Knob, Button } from '@nafr/echo-ui'
 import { Play, Hand } from 'lucide-react'
 
-export const EchoEnvelopADSR = () => {
-  const envelopeData: EnvelopeData = {
-    attack: 0.6,
-    decay: 0.2,
-    sustain: 0.8,
-    release: 0.2,
-  }
+type EnvelopeVoice = {
+  envelope: Tone.AmplitudeEnvelope
+  oscillator: Tone.Oscillator
+}
 
+const disposeVoice = (voice: EnvelopeVoice | null) => {
+  if (!voice) return
+  try {
+    voice.oscillator.stop()
+  } catch {
+    // The oscillator may already have stopped at the scheduled release.
+  }
+  voice.oscillator.dispose()
+  voice.envelope.dispose()
+}
+
+export const EchoEnvelopADSR = () => {
+  const envelopeData: EnvelopeData = { attack: 0.6, decay: 0.2, sustain: 0.8, release: 0.2 }
   const [data, setData] = useState({ ...envelopeData })
   const [attack, setAttack] = useState(envelopeData.attack)
   const [decay, setDecay] = useState(envelopeData.decay)
   const [sustain, setSustain] = useState(envelopeData.sustain)
   const [release, setRelease] = useState(envelopeData.release)
   const [isPlaying, setIsPlaying] = useState(false)
+  const voice = useRef<EnvelopeVoice | null>(null)
+  const releaseTimer = useRef(0)
+  const voiceVersion = useRef(0)
 
-  useEffect(() => {
-    setData({ attack, decay, sustain, release })
-  }, [attack, decay, sustain, release])
+  useEffect(() => setData({ attack, decay, sustain, release }), [attack, decay, sustain, release])
 
-  const handleDataChange = (data: EnvelopeData) => {
-    setAttack(data.attack)
-    setDecay(data.decay)
-    setSustain(data.sustain)
-    setRelease(data.release)
-  }
+  const releaseCurrentVoice = useCallback(() => {
+    voiceVersion.current += 1
+    if (releaseTimer.current) window.clearTimeout(releaseTimer.current)
+    releaseTimer.current = 0
+    const currentVoice = voice.current
+    voice.current = null
+    disposeVoice(currentVoice)
+  }, [])
 
-  const envelope = useRef<Tone.AmplitudeEnvelope | null>(null)
-  const oscillator = useRef<Tone.Oscillator | null>(null)
+  useEffect(() => releaseCurrentVoice, [releaseCurrentVoice])
 
-  const handleMouseDown = () => {
-    setIsPlaying(true)
-    envelope.current = new Tone.AmplitudeEnvelope({
-      attack,
-      decay,
-      sustain,
-      release,
-    }).toDestination()
-    oscillator.current = new Tone.Oscillator().connect(envelope.current).start()
-    envelope.current.triggerAttack()
+  const handleMouseDown = async () => {
+    releaseCurrentVoice()
+    const version = voiceVersion.current
+    try {
+      await Tone.start()
+      if (version !== voiceVersion.current) return
+      const nextEnvelope = new Tone.AmplitudeEnvelope({
+        attack,
+        decay,
+        sustain,
+        release,
+      }).toDestination()
+      const nextOscillator = new Tone.Oscillator().connect(nextEnvelope)
+      voice.current = { envelope: nextEnvelope, oscillator: nextOscillator }
+      nextOscillator.start()
+      nextEnvelope.triggerAttack()
+      setIsPlaying(true)
+    } catch {
+      releaseCurrentVoice()
+      setIsPlaying(false)
+    }
   }
 
   const handleMouseUp = () => {
+    const currentVoice = voice.current
+    if (!currentVoice) return
+    currentVoice.envelope.triggerRelease()
+    releaseTimer.current = window.setTimeout(
+      () => {
+        if (voice.current === currentVoice) voice.current = null
+        disposeVoice(currentVoice)
+        releaseTimer.current = 0
+      },
+      release * 1000 + 20,
+    )
     setIsPlaying(false)
-    if (!envelope.current) return
-    envelope.current.triggerRelease()
-
-    setTimeout(() => {
-      if (!envelope.current || !oscillator.current) return
-      oscillator.current.stop()
-      oscillator.current.dispose()
-      envelope.current.dispose()
-    }, release * 1000)
   }
 
   return (
-    <section className="flex flex-col items-center w-2/3">
+    <section
+      className="flex flex-col items-center w-2/3"
+      data-audio-example="envelope-adsr"
+      data-audio-state={isPlaying ? 'playing' : 'stopped'}
+    >
       <Button
+        aria-label="Hold ADSR envelope"
         className="mb-5 cursor-grab"
         toggled={isPlaying}
         onMouseDown={handleMouseDown}
+        onMouseLeave={handleMouseUp}
         onMouseUp={handleMouseUp}
       >
         <Hand className="w-4 h-4" />
       </Button>
 
-      <Envelope data={data} onChange={handleDataChange} />
+      <Envelope
+        data={data}
+        onChange={({ attack, decay, sustain, release }) => {
+          setAttack(attack)
+          setDecay(decay)
+          setSustain(sustain)
+          setRelease(release)
+        }}
+      />
 
       <Knob.Group
         className="gap-8 mt-5 w-full justify-center"
@@ -100,7 +139,6 @@ export const EchoEnvelopAHDSR = () => {
     sustain: 0.8,
     release: 0.2,
   }
-
   const [data, setData] = useState({ ...envelopeData })
   const [delay, setDelay] = useState(envelopeData.delay)
   const [attack, setAttack] = useState(envelopeData.attack)
@@ -108,42 +146,85 @@ export const EchoEnvelopAHDSR = () => {
   const [decay, setDecay] = useState(envelopeData.decay)
   const [sustain, setSustain] = useState(envelopeData.sustain)
   const [release, setRelease] = useState(envelopeData.release)
+  const [scheduled, setScheduled] = useState(false)
+  const voice = useRef<EnvelopeVoice | null>(null)
+  const disposeTimer = useRef(0)
+  const voiceVersion = useRef(0)
 
-  useEffect(() => {
-    setData({ delay, attack, decay, hold, sustain, release })
-  }, [delay, attack, hold, decay, sustain, release])
+  useEffect(
+    () => setData({ delay, attack, decay, hold, sustain, release }),
+    [delay, attack, hold, decay, sustain, release],
+  )
 
-  const handleDataChange = (data: EnvelopeData) => {
-    setDelay(data.delay)
-    setAttack(data.attack)
-    setDecay(data.decay)
-    setHold(data.hold)
-    setSustain(data.sustain)
-    setRelease(data.release)
-  }
+  const releaseCurrentVoice = useCallback(() => {
+    voiceVersion.current += 1
+    if (disposeTimer.current) window.clearTimeout(disposeTimer.current)
+    disposeTimer.current = 0
+    const currentVoice = voice.current
+    voice.current = null
+    disposeVoice(currentVoice)
+  }, [])
 
-  const envelope = useRef<Tone.AmplitudeEnvelope | null>(null)
-  const oscillator = useRef<Tone.Oscillator | null>(null)
+  useEffect(() => releaseCurrentVoice, [releaseCurrentVoice])
 
-  const handleMouseDown = () => {
-    envelope.current = new Tone.AmplitudeEnvelope({
-      attack,
-      decay,
-      sustain,
-      release,
-    }).toDestination()
-    oscillator.current = new Tone.Oscillator().connect(envelope.current).start()
-    envelope.current.triggerAttack(`+${delay || 0}`)
-    envelope.current.triggerRelease(`+${delay! + attack + hold! + decay}}`)
+  const handleTrigger = async () => {
+    releaseCurrentVoice()
+    const version = voiceVersion.current
+    try {
+      await Tone.start()
+      if (version !== voiceVersion.current) return
+      const nextEnvelope = new Tone.AmplitudeEnvelope({
+        attack,
+        decay,
+        sustain,
+        release,
+      }).toDestination()
+      const nextOscillator = new Tone.Oscillator().connect(nextEnvelope)
+      const now = nextEnvelope.immediate()
+      const attackAt = now + (delay ?? 0)
+      const releaseAt = attackAt + attack + (hold ?? 0) + decay
+      const nextVoice = { envelope: nextEnvelope, oscillator: nextOscillator }
+      voice.current = nextVoice
+      nextOscillator.start(now)
+      nextEnvelope.triggerAttack(attackAt)
+      nextEnvelope.triggerRelease(releaseAt)
+      setScheduled(true)
+      disposeTimer.current = window.setTimeout(
+        () => {
+          if (voice.current === nextVoice) voice.current = null
+          disposeVoice(nextVoice)
+          disposeTimer.current = 0
+          setScheduled(false)
+        },
+        (releaseAt + release - now) * 1000 + 20,
+      )
+    } catch {
+      releaseCurrentVoice()
+      setScheduled(false)
+    }
   }
 
   return (
-    <section className="flex flex-col items-center w-2/3">
-      <Button className="mb-5" onMouseDown={handleMouseDown}>
+    <section
+      className="flex flex-col items-center w-2/3"
+      data-audio-example="envelope-ahdsr"
+      data-audio-state={scheduled ? 'scheduled' : 'stopped'}
+    >
+      <Button aria-label="Trigger AHDSR envelope" className="mb-5" onMouseDown={handleTrigger}>
         <Play className="w-4 h-4 fill-current" />
       </Button>
 
-      <Envelope data={data} onChange={handleDataChange} />
+      <Envelope
+        data={data}
+        onChange={({ delay, attack, hold, decay, sustain, release }) => {
+          setDelay(delay)
+          setAttack(attack)
+          setHold(hold)
+          setDecay(decay)
+          setSustain(sustain)
+          setRelease(release)
+        }}
+      />
 
       <Knob.Group
         className="gap-8 mt-5 w-full justify-center"

--- a/example/src/components/controls/UncontrolledSlider.tsx
+++ b/example/src/components/controls/UncontrolledSlider.tsx
@@ -6,7 +6,7 @@ import { Slider, Button } from '@nafr/echo-ui'
 const meterValue = (value: number | number[]) => (typeof value === 'number' ? value : value[0])
 
 export const UncontrolledSlider = () => {
-  const url = 'https://codeacme17.github.io/1llest-waveform-vue/audios/loop-1.mp3'
+  const url = '/audio/Drum Loop.wav'
   const [value, setValue] = useState(-60)
   const [ready, setReady] = useState(false)
   const [isPlay, setIsPlay] = useState(false)
@@ -74,8 +74,18 @@ export const UncontrolledSlider = () => {
   }
 
   return (
-    <section className="flex flex-col items-center">
-      <Button onClick={handlePlay} disabled={!ready} toggled={isPlay} className="mb-5 px-4">
+    <section
+      className="flex flex-col items-center"
+      data-audio-example="player-meter-slider"
+      data-audio-state={isPlay ? 'playing' : 'stopped'}
+    >
+      <Button
+        aria-label={isPlay ? 'Stop player meter' : 'Start player meter'}
+        onClick={handlePlay}
+        disabled={!ready}
+        toggled={isPlay}
+        className="mb-5 px-4"
+      >
         {isPlay ? (
           <Square className="w-4 h-4 fill-current" />
         ) : (

--- a/example/src/components/controls/UncontrolledSlider.tsx
+++ b/example/src/components/controls/UncontrolledSlider.tsx
@@ -1,59 +1,87 @@
 import * as Tone from 'tone'
-import { useEffect, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { Play, Square } from 'lucide-react'
 import { Slider, Button } from '@nafr/echo-ui'
 
+const meterValue = (value: number | number[]) => (typeof value === 'number' ? value : value[0])
+
 export const UncontrolledSlider = () => {
   const url = 'https://codeacme17.github.io/1llest-waveform-vue/audios/loop-1.mp3'
-  const [value, setValue] = useState<number>(0)
-  const [player, setPlayer] = useState<Tone.Player | null>(null)
+  const [value, setValue] = useState(-60)
+  const [ready, setReady] = useState(false)
   const [isPlay, setIsPlay] = useState(false)
-  const [meter] = useState<Tone.Meter>(new Tone.Meter())
+  const player = useRef<Tone.Player | null>(null)
+  const meter = useRef<Tone.Meter | null>(null)
+  const frameId = useRef(0)
 
-  const handlePlay = () => {
-    setIsPlay(!isPlay)
-    if (!player) return
-    player.volume.value = 5
-
-    if (player.state === 'started') {
-      player.stop()
-      return
-    }
-
-    player.start()
-    player.connect(meter)
-    getDB()
-  }
-
-  useEffect(() => {
-    const player = new Tone.Player(url).toDestination()
-    setPlayer(player)
-
-    return () => {
-      player.stop()
-      player.disconnect()
-    }
+  const cancelObservation = useCallback(() => {
+    if (!frameId.current) return
+    cancelAnimationFrame(frameId.current)
+    frameId.current = 0
   }, [])
 
-  const getDB = () => {
-    if (player?.state === 'stopped') {
+  const observeLevel = useCallback(() => {
+    const readLevel = () => {
+      const currentPlayer = player.current
+      const currentMeter = meter.current
+      if (!currentPlayer || !currentMeter || currentPlayer.state === 'stopped') {
+        frameId.current = 0
+        setValue(-60)
+        return
+      }
+      setValue(meterValue(currentMeter.getValue()))
+      frameId.current = requestAnimationFrame(readLevel)
+    }
+    if (!frameId.current) frameId.current = requestAnimationFrame(readLevel)
+  }, [])
+
+  useEffect(() => {
+    const nextMeter = new Tone.Meter()
+    const nextPlayer = new Tone.Player(url, () => setReady(true)).toDestination()
+    nextPlayer.connect(nextMeter)
+    meter.current = nextMeter
+    player.current = nextPlayer
+
+    return () => {
+      cancelObservation()
+      try {
+        nextPlayer.stop()
+      } catch {
+        // The remote player may not have loaded before unmount.
+      }
+      nextPlayer.dispose()
+      nextMeter.dispose()
+      player.current = null
+      meter.current = null
+    }
+  }, [cancelObservation])
+
+  const handlePlay = async () => {
+    const currentPlayer = player.current
+    if (!currentPlayer || !ready) return
+    await Tone.start()
+    currentPlayer.volume.value = 5
+    if (currentPlayer.state === 'started') {
+      currentPlayer.stop()
+      cancelObservation()
       setValue(-60)
+      setIsPlay(false)
       return
     }
-    setValue(meter.getValue() as number)
-    requestAnimationFrame(getDB)
+    currentPlayer.start()
+    observeLevel()
+    setIsPlay(true)
   }
 
   return (
     <section className="flex flex-col items-center">
-      <Button onClick={handlePlay} disabled={!player} toggled={isPlay} className="mb-5 px-4">
+      <Button onClick={handlePlay} disabled={!ready} toggled={isPlay} className="mb-5 px-4">
         {isPlay ? (
           <Square className="w-4 h-4 fill-current" />
         ) : (
           <Play className="w-4 h-4 fill-current" />
         )}
       </Button>
-
       <div className="h-80">
         <Slider
           className="w-2"

--- a/example/src/components/visualizaion/EchoLFO.tsx
+++ b/example/src/components/visualizaion/EchoLFO.tsx
@@ -9,48 +9,64 @@ export const EchoLFO = () => {
   const [amplitude, setAmplitude] = React.useState(0)
   const [delay, setDelay] = React.useState(0)
   const [isPlaying, setIsPlaying] = React.useState(false)
-
   const autoFilter = React.useRef<Tone.AutoFilter | null>(null)
   const osc = React.useRef<Tone.Oscillator | null>(null)
 
-  React.useEffect(() => {
-    autoFilter.current = new Tone.AutoFilter({
-      frequency: frequency,
-      depth: 1,
-    })
-      .toDestination()
-      .start()
-
-    osc.current = new Tone.Oscillator({
-      volume: amplitude,
-      frequency: 'C4',
-    }).connect(autoFilter.current)
+  const disposeVoice = React.useCallback(() => {
+    const currentOscillator = osc.current
+    const currentFilter = autoFilter.current
+    osc.current = null
+    autoFilter.current = null
+    try {
+      currentOscillator?.stop()
+      currentFilter?.stop()
+    } catch {
+      // Tone sources may already be stopped during unmount.
+    }
+    currentOscillator?.dispose()
+    currentFilter?.dispose()
   }, [])
 
+  React.useEffect(() => disposeVoice, [disposeVoice])
+
   React.useEffect(() => {
-    autoFilter.current?.set({
-      frequency: frequency,
-    })
+    autoFilter.current?.set({ frequency })
+    osc.current?.set({ type, frequency: 440, volume: amplitude })
+  }, [type, frequency, amplitude])
 
-    osc.current?.set({
-      type,
-      frequency: 440,
-      volume: amplitude,
-    })
-  }, [type, frequency, amplitude, delay])
-
-  const triggerPlay = () => {
+  const triggerPlay = async () => {
     if (isPlaying) {
-      osc.current?.stop()
+      disposeVoice()
       setIsPlaying(false)
-    } else {
-      osc.current?.start()
+      return
+    }
+
+    try {
+      await Tone.start()
+      disposeVoice()
+      const nextFilter = new Tone.AutoFilter({ depth: 1, frequency }).toDestination().start()
+      const nextOscillator = new Tone.Oscillator({
+        frequency: 'C4',
+        type,
+        volume: amplitude,
+      }).connect(nextFilter)
+      nextOscillator.start(`+${delay / 1000}`)
+      autoFilter.current = nextFilter
+      osc.current = nextOscillator
       setIsPlaying(true)
+    } catch {
+      disposeVoice()
+      setIsPlaying(false)
     }
   }
 
   return (
-    <section className="h-32 w-2/3 mb-32">
+    <section
+      className="h-32 w-2/3 mb-32"
+      data-audio-example="lfo"
+      data-audio-state={isPlaying ? 'playing' : 'stopped'}
+      data-tone-version={Tone.version}
+    >
       <Button.Group className="mb-2" radius="sm">
         <Button toggled={type === 'sine'} onClick={() => setType('sine')}>
           <SineIcon />
@@ -63,7 +79,7 @@ export const EchoLFO = () => {
         </Button>
       </Button.Group>
 
-      <Button onClick={triggerPlay}>
+      <Button aria-label={isPlaying ? 'Stop LFO' : 'Start LFO'} onClick={triggerPlay}>
         {isPlaying ? <StopCircle size={24} /> : <Play size={24} />}
       </Button>
 

--- a/example/src/components/visualizaion/EchoOsci.tsx
+++ b/example/src/components/visualizaion/EchoOsci.tsx
@@ -1,10 +1,11 @@
 import { useEffect } from 'react'
+import * as Tone from 'tone'
 import { Oscilloscope, Button, useOscilloscope, usePlayer, useFetchAudio } from '@nafr/echo-ui'
 
 export const EchoOsci = () => {
   const url = '/audio/Drum Loop.wav'
-  const { audioBuffer, fetchAudio } = useFetchAudio({ url })
-  const { init: initPlayer, isPlaying, play, pause } = usePlayer()
+  const { audioBuffer, fetchAudio, pending } = useFetchAudio({ url })
+  const { init: initPlayer, isPlaying, isReady, play, pause } = usePlayer()
   const { observer, cancelObserve, analyser, init: initOscilloscope, data } = useOscilloscope()
 
   useEffect(() => {
@@ -17,7 +18,8 @@ export const EchoOsci = () => {
     initPlayer(audioBuffer, [analyser.current])
   }, [audioBuffer, analyser])
 
-  const handleTrigger = () => {
+  const handleTrigger = async () => {
+    await Tone.start()
     if (isPlaying) {
       pause()
       cancelObserve()
@@ -28,10 +30,19 @@ export const EchoOsci = () => {
   }
 
   return (
-    <section className="flex flex-col items-center gap-2 w-1/2">
+    <section
+      className="flex flex-col items-center gap-2 w-1/2"
+      data-audio-example="oscilloscope"
+      data-audio-state={isPlaying ? 'playing' : 'stopped'}
+    >
       <Oscilloscope className="w-full" data={data} amplitudeRange={[-3, 3]} />
 
-      <Button onClick={handleTrigger} toggled={isPlaying}>
+      <Button
+        aria-label={isPlaying ? 'Stop oscilloscope' : 'Start oscilloscope'}
+        disabled={pending || !isReady}
+        onClick={handleTrigger}
+        toggled={isPlaying}
+      >
         {isPlaying ? 'Stop' : 'Start'}
       </Button>
     </section>

--- a/example/src/components/visualizaion/EchoSpectrogram.tsx
+++ b/example/src/components/visualizaion/EchoSpectrogram.tsx
@@ -3,7 +3,7 @@ import React, { useRef } from 'react'
 import { Spectrogram, Button, Knob, useFetchAudio, usePlayer, useSpectrogram } from '@nafr/echo-ui'
 
 export const EchoSpectrogram = () => {
-  const url = 'https://codeacme17.github.io/1llest-waveform-vue/audios/loop-3.mp3'
+  const url = '/audio/Drum Loop.wav'
 
   const filterLow = useRef<Tone.Filter | null>(null)
   const filterMid = useRef<Tone.Filter | null>(null)
@@ -64,12 +64,17 @@ export const EchoSpectrogram = () => {
   }, [low, mid, high])
 
   const handleTrigger = async () => {
+    await Tone.start()
     if (isPlaying) stop()
     else play()
   }
 
   return (
-    <div className="max-w-[500px] min-w-[200px] w-3/4 flex flex-col items-center gap-2">
+    <div
+      className="max-w-[500px] min-w-[200px] w-3/4 flex flex-col items-center gap-2"
+      data-audio-example="spectrogram-filtered"
+      data-audio-state={isPlaying ? 'playing' : 'stopped'}
+    >
       <Knob.Group
         size={50}
         trackWidth={2}
@@ -86,7 +91,12 @@ export const EchoSpectrogram = () => {
 
       <Spectrogram className="w-full h-52" data={data} axis grid shadow />
 
-      <Button disabled={pending} onClick={handleTrigger} toggled={isPlaying}>
+      <Button
+        aria-label={isPlaying ? 'Stop filtered spectrogram' : 'Start filtered spectrogram'}
+        disabled={pending}
+        onClick={handleTrigger}
+        toggled={isPlaying}
+      >
         {isPlaying ? 'Stop' : 'Start'}
       </Button>
     </div>
@@ -94,7 +104,7 @@ export const EchoSpectrogram = () => {
 }
 
 export const SpectrogramDefault = () => {
-  const url = 'https://codeacme17.github.io/1llest-waveform-vue/audios/loop-3.mp3'
+  const url = '/audio/Drum Loop.wav'
 
   const { audioBuffer, pending, fetchAudio } = useFetchAudio({ url })
   const { analyser, data, init: initSpectrogram, observe, cancelObserve } = useSpectrogram()
@@ -120,15 +130,25 @@ export const SpectrogramDefault = () => {
   }, [audioBuffer, analyser.current])
 
   const handleTrigger = async () => {
+    await Tone.start()
     if (isPlaying) stop()
     else play()
   }
 
   return (
-    <div className="max-w-[500px] min-w-[200px] w-3/4 flex flex-col items-center gap-2">
+    <div
+      className="max-w-[500px] min-w-[200px] w-3/4 flex flex-col items-center gap-2"
+      data-audio-example="spectrogram-default"
+      data-audio-state={isPlaying ? 'playing' : 'stopped'}
+    >
       <Spectrogram className="w-full h-52" data={data} axis grid shadow shadowDirection="top" />
 
-      <Button onClick={handleTrigger} disabled={pending} toggled={isPlaying}>
+      <Button
+        aria-label={isPlaying ? 'Stop default spectrogram' : 'Start default spectrogram'}
+        onClick={handleTrigger}
+        disabled={pending}
+        toggled={isPlaying}
+      >
         {isPlaying ? 'Stop' : 'Start'}
       </Button>
     </div>

--- a/example/src/components/visualizaion/EchoSpectrogram.tsx
+++ b/example/src/components/visualizaion/EchoSpectrogram.tsx
@@ -36,6 +36,15 @@ export const EchoSpectrogram = () => {
     filterLow.current = new Tone.Filter(LOW_FREQ, 'lowshelf')
     filterMid.current = new Tone.Filter(MID_FREQ, 'peaking')
     filterHigh.current = new Tone.Filter(HIGH_FREQ, 'highshelf')
+
+    return () => {
+      filterLow.current?.dispose()
+      filterMid.current?.dispose()
+      filterHigh.current?.dispose()
+      filterLow.current = null
+      filterMid.current = null
+      filterHigh.current = null
+    }
   }, [])
 
   React.useEffect(() => {

--- a/example/src/components/visualizaion/EchoWaveform.tsx
+++ b/example/src/components/visualizaion/EchoWaveform.tsx
@@ -8,9 +8,10 @@ import {
 } from '@nafr/echo-ui'
 import { useEffect } from 'react'
 import { Play, Square, Pause, Repeat, VolumeX } from 'lucide-react'
+import * as Tone from 'tone'
 
 export const EchoWaveform = () => {
-  const url = 'https://codeacme17.github.io/1llest-waveform-vue/audios/loop-3.mp3'
+  const url = '/audio/Drum Loop.wav'
 
   const { pending, error, audioBuffer, fetchAudio } = useFetchAudio({ url })
   const { data, audioDuration } = useWaveform({ audioBuffer })
@@ -44,7 +45,8 @@ export const EchoWaveform = () => {
     init(audioBuffer)
   }, [audioBuffer])
 
-  const togglePlay = () => {
+  const togglePlay = async () => {
+    await Tone.start()
     if (isPlaying) pause()
     else play()
   }
@@ -54,7 +56,11 @@ export const EchoWaveform = () => {
   }
 
   return (
-    <section className="w-2/3 flex flex-col justify-center items-center">
+    <section
+      className="w-2/3 flex flex-col justify-center items-center"
+      data-audio-example="waveform"
+      data-audio-state={isPlaying ? 'playing' : 'stopped'}
+    >
       <Waveform
         data={data}
         audioDuration={audioDuration.current}
@@ -73,7 +79,11 @@ export const EchoWaveform = () => {
           <Square className="w-4 h-4 fill-current" />
         </Button>
 
-        <Button onClick={togglePlay} toggled={isPlaying}>
+        <Button
+          aria-label={isPlaying ? 'Pause waveform' : 'Start waveform'}
+          onClick={togglePlay}
+          toggled={isPlaying}
+        >
           {isPlaying ? (
             <Pause className="w-4 h-4 fill-current" />
           ) : (

--- a/example/src/components/visualizaion/VuMeter/EchoMono.tsx
+++ b/example/src/components/visualizaion/VuMeter/EchoMono.tsx
@@ -1,9 +1,10 @@
 import { VuMeter, Button, Slider, useFetchAudio, usePlayer, useVuMeter } from '@nafr/echo-ui'
 import { Play, Square, Pause, Repeat, VolumeX } from 'lucide-react'
 import { useEffect } from 'react'
+import * as Tone from 'tone'
 
 export const VuMeterMono = () => {
-  const url = 'https://codeacme17.github.io/1llest-waveform-vue/audios/loop-1.mp3'
+  const url = '/audio/Drum Loop.wav'
 
   const { pending, error, audioBuffer, fetchAudio } = useFetchAudio({ url })
   const { meter, value, init: initVuMeter, observe, cancelObserve } = useVuMeter({ value: -60 })
@@ -47,16 +48,25 @@ export const VuMeterMono = () => {
     cancelObserve()
   }
 
-  const handleTriggerPlay = () => {
+  const handleTriggerPlay = async () => {
     if (!player.current) return
+    await Tone.start()
     if (isPlaying) pause()
     else play()
   }
 
   return (
-    <section className="w-80 items-center flex flex-col">
+    <section
+      className="w-80 items-center flex flex-col"
+      data-audio-example="vu-mono"
+      data-audio-state={isPlaying ? 'playing' : 'stopped'}
+    >
       <Button.Group className="mb-3" disabled={pending || error || !isReady}>
-        <Button onClick={handleTriggerPlay} toggled={isPlaying}>
+        <Button
+          aria-label={isPlaying ? 'Pause mono VU' : 'Start mono VU'}
+          onClick={handleTriggerPlay}
+          toggled={isPlaying}
+        >
           {isPlaying ? (
             <Pause className="w-4 h-4 fill-current" />
           ) : (

--- a/example/src/components/visualizaion/VuMeter/EchoRecord.tsx
+++ b/example/src/components/visualizaion/VuMeter/EchoRecord.tsx
@@ -13,6 +13,7 @@ export const VuMeterRecord = () => {
 
   useEffect(() => {
     return () => {
+      void recorder.close()
       recorder.dispose()
       split.dispose()
       meterLeft.dispose()
@@ -21,16 +22,19 @@ export const VuMeterRecord = () => {
   }, [recorder, split, meterLeft, meterRight])
 
   const handleRecord = async () => {
-    // Toggle the recording state
-    setIsRecording(!isRecording)
-
     if (isRecording) {
+      setIsRecording(false)
+      recorder.disconnect()
       split.disconnect()
+      await recorder.close()
     } else {
-      recorder.open()
+      await Tone.start()
+      await recorder.open()
+      split.disconnect()
       recorder.connect(split)
-      split.connect(meterLeft)
-      split.connect(meterRight)
+      split.connect(meterLeft, 0)
+      split.connect(meterRight, 1)
+      setIsRecording(true)
     }
   }
 
@@ -43,10 +47,12 @@ export const VuMeterRecord = () => {
         return
       }
 
-      const levelLeft = meterLeft.getValue()
-      const levelRight = meterRight.getValue()
+      const leftValue = meterLeft.getValue()
+      const rightValue = meterRight.getValue()
+      const levelLeft = typeof leftValue === 'number' ? leftValue : leftValue[0]
+      const levelRight = typeof rightValue === 'number' ? rightValue : rightValue[0]
 
-      setValue([levelLeft, levelRight] as number[])
+      setValue([levelLeft, levelRight])
       animationFrameId = requestAnimationFrame(getDB)
     }
 

--- a/example/src/components/visualizaion/VuMeter/EchoRecord.tsx
+++ b/example/src/components/visualizaion/VuMeter/EchoRecord.tsx
@@ -7,33 +7,25 @@ export const VuMeterRecord = () => {
   const [value, setValue] = useState([-60, -60])
   const [isRecording, setIsRecording] = useState(false)
   const [recorder] = useState(() => new Tone.UserMedia())
-  const [split] = useState(() => new Tone.Split())
-  const [meterLeft] = useState(() => new Tone.Meter())
-  const [meterRight] = useState(() => new Tone.Meter())
+  const [meter] = useState(() => new Tone.Meter({ channelCount: 2 }))
 
   useEffect(() => {
     return () => {
       void recorder.close()
       recorder.dispose()
-      split.dispose()
-      meterLeft.dispose()
-      meterRight.dispose()
+      meter.dispose()
     }
-  }, [recorder, split, meterLeft, meterRight])
+  }, [meter, recorder])
 
   const handleRecord = async () => {
     if (isRecording) {
       setIsRecording(false)
       recorder.disconnect()
-      split.disconnect()
       await recorder.close()
     } else {
       await Tone.start()
       await recorder.open()
-      split.disconnect()
-      recorder.connect(split)
-      split.connect(meterLeft, 0)
-      split.connect(meterRight, 1)
+      recorder.connect(meter)
       setIsRecording(true)
     }
   }
@@ -47,12 +39,8 @@ export const VuMeterRecord = () => {
         return
       }
 
-      const leftValue = meterLeft.getValue()
-      const rightValue = meterRight.getValue()
-      const levelLeft = typeof leftValue === 'number' ? leftValue : leftValue[0]
-      const levelRight = typeof rightValue === 'number' ? rightValue : rightValue[0]
-
-      setValue([levelLeft, levelRight])
+      const currentValue = meter.getValue()
+      setValue(typeof currentValue === 'number' ? [currentValue, currentValue] : currentValue)
       animationFrameId = requestAnimationFrame(getDB)
     }
 
@@ -63,11 +51,20 @@ export const VuMeterRecord = () => {
     return () => {
       cancelAnimationFrame(animationFrameId)
     }
-  }, [isRecording, meterLeft, meterRight])
+  }, [isRecording, meter])
 
   return (
-    <section className="flex flex-col justify-center items-center">
-      <Button onClick={handleRecord} toggled={isRecording} className="mb-5">
+    <section
+      className="flex flex-col justify-center items-center"
+      data-audio-example="microphone-vu"
+      data-audio-state={isRecording ? 'recording' : 'stopped'}
+    >
+      <Button
+        aria-label={isRecording ? 'Stop microphone VU' : 'Start microphone VU'}
+        onClick={handleRecord}
+        toggled={isRecording}
+        className="mb-5"
+      >
         <Circle className="w-4 h-4 fill-current" />
       </Button>
 

--- a/example/src/components/visualizaion/VuMeter/EchoStereo.tsx
+++ b/example/src/components/visualizaion/VuMeter/EchoStereo.tsx
@@ -1,7 +1,8 @@
 import React from 'react'
+import * as Tone from 'tone'
 import { VuMeter, Button, usePlayer, useFetchAudio, useVuMeter } from '@nafr/echo-ui'
 
-const url = 'https://codeacme17.github.io/1llest-waveform-vue/audios/loop-1.mp3'
+const url = '/audio/Drum Loop.wav'
 
 export const VueMeterStereo = () => {
   const { audioBuffer, pending, fetchAudio } = useFetchAudio({ url })
@@ -13,6 +14,7 @@ export const VueMeterStereo = () => {
     cancelObserve,
   } = useVuMeter({ value: [-60, -60] })
   const {
+    isReady,
     isPlaying,
     init: initPlayer,
     play,
@@ -32,14 +34,21 @@ export const VueMeterStereo = () => {
     initPlayer(audioBuffer, [meter.current])
   }, [audioBuffer, meter.current])
 
-  const handleClick = () => {
+  const handleClick = async () => {
+    await Tone.start()
     if (isPlaying) pause()
     else play()
   }
 
   return (
-    <section className="">
-      <Button disabled={pending} toggled={isPlaying} className="mb-5 px-4" onClick={handleClick}>
+    <section data-audio-example="vu-stereo" data-audio-state={isPlaying ? 'playing' : 'stopped'}>
+      <Button
+        aria-label={isPlaying ? 'Pause stereo VU' : 'Start stereo VU'}
+        disabled={pending || !isReady}
+        toggled={isPlaying}
+        className="mb-5 px-4"
+        onClick={handleClick}
+      >
         Stereo
       </Button>
 

--- a/package.json
+++ b/package.json
@@ -53,8 +53,10 @@
     "build": "vite build && tsc",
     "typecheck": "tsc --noEmit",
     "lint": "eslint . --max-warnings 0",
-    "test": "pnpm build && vitest run && pnpm test:react-compat && node scripts/smoke-tailwind-consumers.mjs",
+    "test": "pnpm build && vitest run && pnpm test:react-compat && pnpm test:tone-browser && node scripts/smoke-tailwind-consumers.mjs",
     "test:react-compat": "node scripts/smoke-react-consumers.mjs",
+    "test:tone-browser": "node scripts/smoke-tone-hooks.mjs",
+    "test:tone-examples": "node scripts/smoke-tone-examples.mjs",
     "test:tailwind-compat": "pnpm build && node scripts/smoke-tailwind-consumers.mjs",
     "test:tailwind-docs": "node scripts/verify-tailwind-installation-docs.mjs",
     "test:watch": "vitest",
@@ -67,7 +69,7 @@
     "preview:docs": "node scripts/serve-docs.mjs",
     "typecheck:docs": "pnpm --filter @nafr/echo-ui-docs typecheck",
     "test:docs": "pnpm test:tailwind-docs && node scripts/verify-nextra-output.mjs && node scripts/smoke-nextra-routes.mjs && node scripts/verify-docs-ui.mjs",
-    "verify": "pnpm typecheck && pnpm typecheck:example && pnpm typecheck:docs && pnpm test && pnpm build:example && pnpm build:docs && pnpm test:docs",
+    "verify": "pnpm typecheck && pnpm typecheck:example && pnpm typecheck:docs && pnpm test && pnpm build:example && pnpm test:tone-examples && pnpm build:docs && pnpm test:docs",
     "verify:frozen": "pnpm install --frozen-lockfile && pnpm verify"
   },
   "devDependencies": {
@@ -99,7 +101,7 @@
     "d3": "^7.9.0",
     "tailwind-merge": "^3.6.0",
     "tailwind-variants": "^3.2.2",
-    "tone": "^14.7.77"
+    "tone": "^15.1.22"
   },
   "peerDependencies": {
     "react": "^18.2.0 || ^19.0.0",

--- a/packages/hooks/useEnvelope.ts
+++ b/packages/hooks/useEnvelope.ts
@@ -1,5 +1,5 @@
 import * as Tone from 'tone'
-import { useRef, useState, useEffect } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { LIMITS } from '../components/controller/Envelope/constants'
 import type { EnvelopeData, EnvelopeLimits } from '../components/controller/Envelope'
 
@@ -9,46 +9,49 @@ export interface UseEnvelopeProps {
 }
 
 export const useEnvelope = (props: UseEnvelopeProps) => {
-  const { data: _data, limits = LIMITS } = props
+  const { data: initialData, limits = LIMITS } = props
 
-  const [data, setData] = useState({ ..._data })
-  const envelope = useRef<Tone.Envelope | null>(null)
+  const [data, setData] = useState({ ...initialData })
+  const envelope = useRef<Tone.AmplitudeEnvelope | null>(null)
+  const [delay, setDelay] = useState(initialData.delay)
+  const [attack, setAttack] = useState(initialData.attack)
+  const [hold, setHold] = useState(initialData.hold)
+  const [decay, setDecay] = useState(initialData.decay)
+  const [sustain, setSustain] = useState(initialData.sustain)
+  const [release, setRelease] = useState(initialData.release)
 
-  const [delay, setDelay] = useState(_data.delay)
-  const [attack, setAttack] = useState(_data.attack)
-  const [hold, setHold] = useState(_data.hold)
-  const [decay, setDecay] = useState(_data.decay)
-  const [sustain, setSustain] = useState(_data.sustain)
-  const [release, setRelease] = useState(_data.release)
+  const releaseEnvelope = useCallback(() => {
+    envelope.current?.dispose()
+    envelope.current = null
+  }, [])
+
+  useEffect(() => releaseEnvelope, [releaseEnvelope])
 
   useEffect(() => {
-    if (!envelope.current) return
+    const currentEnvelope = envelope.current
+    if (!currentEnvelope) return
 
-    envelope.current.attack = attack
-    envelope.current.decay = decay
-    envelope.current.sustain = sustain
-    envelope.current.release = release
-    setData({ attack, decay, sustain, release })
+    currentEnvelope.attack = attack
+    currentEnvelope.decay = decay
+    currentEnvelope.sustain = sustain
+    currentEnvelope.release = release
+    const nextData = { attack, decay, sustain, release, delay, hold }
+    setData(nextData)
 
-    if (_data.delay !== undefined) {
-      envelope.current.triggerAttack(`+${delay || 0}`)
-      setData({ delay, attack, decay, sustain, release })
-
-      if (_data.hold !== undefined) {
-        envelope.current.triggerRelease(`+${delay! + attack + hold! + decay}}`)
-        setData({ delay, attack, decay, hold, sustain, release })
+    if (delay !== undefined) {
+      const now = currentEnvelope.immediate()
+      currentEnvelope.cancel(now)
+      currentEnvelope.triggerAttack(now + delay)
+      if (hold !== undefined) {
+        currentEnvelope.triggerRelease(now + delay + attack + hold + decay)
       }
     }
-  }, [delay, attack, hold, decay, sustain, release])
+  }, [attack, decay, delay, hold, release, sustain])
 
-  const init = () => {
-    envelope.current = new Tone.AmplitudeEnvelope({
-      attack: data.attack,
-      decay: data.decay,
-      sustain: data.sustain,
-      release: data.release,
-    })
-  }
+  const init = useCallback(() => {
+    releaseEnvelope()
+    envelope.current = new Tone.AmplitudeEnvelope({ attack, decay, sustain, release })
+  }, [attack, decay, release, releaseEnvelope, sustain])
 
   return {
     init,

--- a/packages/hooks/useFetchAudio.ts
+++ b/packages/hooks/useFetchAudio.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { logger } from '../lib/log'
 
 export interface UseFetchAudioProps {
@@ -8,27 +8,7 @@ export interface UseFetchAudioProps {
   onError?: () => void
 }
 
-/**
- * useFetchAudio is a custom React hook for fetching and decoding audio data from a specified URL.
- * It handles the entire process from making an HTTP request to processing the audio data.
- *
- * @param {UseFetchAudioProps} props - The configuration properties for fetching the audio.
- * @param {string} props.url - The URL of the audio file to be fetched.
- * @param {RequestInit} [props.requestOptions] - Optional configuration for the fetch request.
- * @param {Function} [props.onSuccess] - Optional callback to be executed when the audio is successfully fetched and decoded.
- * @param {Function} [props.onError] - Optional callback to be executed in case of an error during fetching or decoding.
- *
- * @returns {object} An object containing several states and a function to initiate the audio fetching:
- * - pending: A boolean indicating whether the request is in progress.
- * - fetched: A boolean indicating whether the audio has been successfully fetched and decoded.
- * - error: A boolean indicating if an error has occurred.
- * - errorMessage: A string containing the error message if an error has occurred.
- * - response: The response object from the fetch request.
- * - audioBuffer: The decoded audio data as an AudioBuffer.
- * - fetchAudio: A function that initiates the fetching and decoding process.
- *
- * This hook is useful in scenarios where you need to retrieve audio files from a server and process them for web audio applications.
- */
+/** Fetches and decodes audio while owning the temporary decoding context and request lifetime. */
 export const useFetchAudio = (props: UseFetchAudioProps) => {
   const { url, requestOptions, onSuccess, onError } = props
 
@@ -38,41 +18,66 @@ export const useFetchAudio = (props: UseFetchAudioProps) => {
   const [errorMessage, setErrorMessage] = useState('')
   const [response, setResponse] = useState<Response | null>(null)
   const [audioBuffer, setAudioBuffer] = useState<AudioBuffer | null>(null)
+  const activeController = useRef<AbortController | null>(null)
+  const requestVersion = useRef(0)
+  const mounted = useRef(true)
 
   useEffect(() => {
-    if (!error) return
-    logger.error(errorMessage)
-    onError?.()
-  }, [error])
+    mounted.current = true
+    return () => {
+      mounted.current = false
+      requestVersion.current += 1
+      activeController.current?.abort()
+      activeController.current = null
+    }
+  }, [])
 
   const fetchAudio = async () => {
-    try {
-      const response = await fetch(url, requestOptions)
-      setResponse(response)
-      setPending(false)
-      if (response.ok) {
-        setFetched(true)
-        decodeBuffer(await response.arrayBuffer())
-        onSuccess?.()
-      } else {
-        throw new Error(response.statusText)
-      }
-    } catch (err) {
-      setError(true)
-      setErrorMessage(err as string)
+    activeController.current?.abort()
+    const controller = new AbortController()
+    activeController.current = controller
+    const version = requestVersion.current + 1
+    requestVersion.current = version
+    const externalSignal = requestOptions?.signal
+    const signal = externalSignal
+      ? AbortSignal.any([controller.signal, externalSignal])
+      : controller.signal
+
+    if (mounted.current) {
+      setPending(true)
+      setFetched(false)
+      setError(false)
+      setErrorMessage('')
+      setAudioBuffer(null)
     }
-  }
 
-  const decodeBuffer = async (arrayBuffer: ArrayBuffer) => {
-    if (error) return
-
+    let audioContext: AudioContext | null = null
     try {
-      const audioContext = new AudioContext()
-      const audioBuffer = await audioContext.decodeAudioData(arrayBuffer)
-      setAudioBuffer(audioBuffer)
+      const nextResponse = await fetch(url, { ...requestOptions, signal })
+      if (!nextResponse.ok) throw new Error(nextResponse.statusText)
+
+      audioContext = new AudioContext()
+      const decodedAudio = await audioContext.decodeAudioData(await nextResponse.arrayBuffer())
+      if (!mounted.current || version !== requestVersion.current) return
+
+      setResponse(nextResponse)
+      setAudioBuffer(decodedAudio)
+      setFetched(true)
+      onSuccess?.()
     } catch (err) {
+      if (controller.signal.aborted || !mounted.current || version !== requestVersion.current)
+        return
+      const message = err instanceof Error ? err.message : String(err)
       setError(true)
-      setErrorMessage(err as string)
+      setErrorMessage(message)
+      logger.error(message)
+      onError?.()
+    } finally {
+      if (audioContext) await audioContext.close()
+      if (mounted.current && version === requestVersion.current) {
+        setPending(false)
+        activeController.current = null
+      }
     }
   }
 

--- a/packages/hooks/useFetchAudio.ts
+++ b/packages/hooks/useFetchAudio.ts
@@ -70,7 +70,7 @@ export const useFetchAudio = (props: UseFetchAudioProps) => {
       const message = err instanceof Error ? err.message : String(err)
       setError(true)
       setErrorMessage(message)
-      logger.error(message)
+      logger.error(err instanceof Error ? String(err) : message)
       onError?.()
     } finally {
       if (audioContext) await audioContext.close()

--- a/packages/hooks/useOscilloscope.ts
+++ b/packages/hooks/useOscilloscope.ts
@@ -41,57 +41,76 @@ export const useOscilloscope = (props: UseOscilloscopeProps = {}) => {
   const [error, setError] = useState<boolean>(false)
   const [errorMessage, setErrorMessage] = useState<string>('')
 
-  useEffect(() => {
-    return () => {
-      analyser.current?.dispose()
-      cancelObserve()
-    }
+  const handleError = useCallback(
+    (err: unknown) => {
+      const message = err instanceof Error ? err.message : String(err)
+      setError(true)
+      setErrorMessage(message)
+      logger.error(message)
+      onError?.()
+    },
+    [onError],
+  )
+
+  const cancelObserve = useCallback(() => {
+    if (!observerId.current) return
+    cancelAnimationFrame(observerId.current)
+    observerId.current = 0
+    setData([])
   }, [])
 
-  const handleError = useCallback((err: unknown) => {
-    setError(true)
-    setErrorMessage(err as string)
-    logger.error(err as string)
-    onError?.()
-  }, [])
+  const releaseAnalyser = useCallback(() => {
+    cancelObserve()
+    analyser.current?.dispose()
+    analyser.current = null
+  }, [cancelObserve])
+
+  useEffect(() => releaseAnalyser, [releaseAnalyser])
 
   const init = useCallback(() => {
     try {
+      releaseAnalyser()
       analyser.current = new Tone.Analyser('waveform', fftSize)
       onReady?.()
     } catch (err) {
       handleError(err)
     }
-  }, [fftSize])
+  }, [fftSize, handleError, onReady, releaseAnalyser])
 
-  const getData = () => {
+  const getData = useCallback(() => {
     if (!analyser.current || error) return
-    const spectrumData = analyser.current.getValue()
-
-    if (spectrumData instanceof Float32Array) {
+    try {
+      const analyserValue: unknown = analyser.current.getValue()
+      const spectrumData =
+        analyserValue instanceof Float32Array
+          ? analyserValue
+          : Array.isArray(analyserValue) && analyserValue[0] instanceof Float32Array
+            ? analyserValue[0]
+            : null
+      if (!spectrumData) return
       const formattedData = Array.from(spectrumData).map((amplitude, index) => {
         return { index, amplitude }
       })
       setData(formattedData)
-    }
-  }
-
-  const observer = useCallback(() => {
-    if (!analyser.current || error) return
-
-    try {
-      observerId.current = requestAnimationFrame(observer)
-      getData()
     } catch (err) {
       handleError(err)
     }
-  }, [])
+  }, [error, handleError])
 
-  const cancelObserve = useCallback(() => {
-    if (!observerId.current) return
-    setData([])
-    cancelAnimationFrame(observerId.current)
-  }, [])
+  const observer = useCallback(() => {
+    if (!analyser.current || error || observerId.current) return
+
+    try {
+      const readFrame = () => {
+        getData()
+        observerId.current = requestAnimationFrame(readFrame)
+      }
+      getData()
+      observerId.current = requestAnimationFrame(readFrame)
+    } catch (err) {
+      handleError(err)
+    }
+  }, [error, getData, handleError])
 
   return {
     init,

--- a/packages/hooks/usePlayer.ts
+++ b/packages/hooks/usePlayer.ts
@@ -18,52 +18,15 @@ const VOLUME = 5
 const LOOP = false
 const MUTE = false
 
-/**
- * usePlayer is a custom React hook that provides functionalities to play, pause, stop, and manage audio playback using Tone.js.
- * It allows control over playback volume, looping, muting, and offers callbacks for various audio playback states.
- *
- * @param {UsePlayerProps} props - Configuration properties for the player.
- * @param {number} props.volume - Initial volume for the player (default: 5).
- * @param {boolean} props.loop - Whether the audio should loop (default: false).
- * @param {boolean} props.mute - Whether the audio should be muted (default: false).
- * @param {Function} props.onReady - Callback executed when the player is ready.
- * @param {Function} props.onPlay - Callback executed when the audio starts playing.
- * @param {Function} props.onPause - Callback executed when the audio is paused.
- * @param {Function} props.onStop - Callback executed when the audio is stopped.
- * @param {Function} props.onFinish - Callback executed when the audio finishes playing.
- * @param {Function} props.onError - Callback executed in case of an error.
- *
- * @returns {object} An object containing various properties and methods for audio playback control:
- * - player: The Tone.js Player instance.
- * - audioDuration: The duration of the loaded audio.
- * - isReady: Boolean indicating if the player is ready.
- * - isPlaying: Boolean indicating if the audio is currently playing.
- * - isFinish: Boolean indicating if the audio has finished playing.
- * - volume: Current volume of the player.
- * - loop: Boolean indicating if the audio is set to loop.
- * - mute: Boolean indicating if the audio is muted.
- * - time: Current playback time.
- * - percentage: Current playback progress as a percentage.
- * - pickTime: Method to set the playback start time.
- * - init: Method to initialize the player with an AudioBuffer.
- * - play: Method to start playback.
- * - pause: Method to pause playback.
- * - stop: Method to stop playback.
- * - getTime: Method to get the current playback time.
- * - setPickTime: Method to set a specific playback time.
- * - setVolume: Method to set the volume.
- * - setLoop: Method to toggle looping.
- * - setMute: Method to toggle mute.
- * - observe: Method to start observing playback state.
- * - cancelObserve: Method to stop observing playback state.
- * - error: Boolean indicating if an error has occurred.
- * - errorMessage: The error message in case of an error.
- */
+const clamp = (value: number, minimum: number, maximum: number) =>
+  Math.min(Math.max(value, minimum), maximum)
+
+/** Owns one Tone.Player and exposes playback/progress controls for a decoded AudioBuffer. */
 export const usePlayer = (props: UsePlayerProps = {}) => {
   const {
-    volume: _volume = VOLUME,
-    loop: _loop = LOOP,
-    mute: _mute = MUTE,
+    volume: initialVolume = VOLUME,
+    loop: initialLoop = LOOP,
+    mute: initialMute = MUTE,
     onReady,
     onPlay,
     onPause,
@@ -73,201 +36,253 @@ export const usePlayer = (props: UsePlayerProps = {}) => {
   } = props
 
   const player = useRef<Tone.Player | null>(null)
-  const startTime = useRef<number>(0)
-  const pauseTime = useRef<number>(0)
-  const pickTime = useRef<number>(0)
+  const startTime = useRef(0)
+  const pauseTime = useRef(0)
+  const pickTime = useRef(0)
   const audioDuration = useRef(0)
-  const observeId = useRef<number>(0)
+  const observeId = useRef(0)
+  const expectedEndTime = useRef(0)
+  const completionArmed = useRef(false)
+  const playingRef = useRef(false)
+  const errorRef = useRef(false)
+  const loopRef = useRef(initialLoop)
+  const callbacks = useRef({ onReady, onPlay, onPause, onStop, onFinish, onError })
+  callbacks.current = { onReady, onPlay, onPause, onStop, onFinish, onError }
 
   const [isReady, setIsReady] = useState(false)
   const [isPlaying, setIsPlaying] = useState(false)
   const [isFinish, setIsFinish] = useState(false)
-  const [volume, setVolume] = useState(_volume)
-  const [loop, setLoop] = useState(_loop)
-  const [mute, setMute] = useState(_mute)
+  const [volume, setVolume] = useState(initialVolume)
+  const [loop, setLoop] = useState(initialLoop)
+  const [mute, setMute] = useState(initialMute)
   const [time, setTime] = useState(0)
   const [percentage, setPercentage] = useState(0)
   const [error, setError] = useState(false)
   const [errorMessage, setErrorMessage] = useState('')
+  loopRef.current = loop
 
-  useEffect(() => {
-    return () => {
-      if (observeId.current) {
-        cancelAnimationFrame(observeId.current)
-        observeId.current = 0
-      }
-      if (!player.current) return
-      player.current.stop()
-      player.current.dispose()
-    }
+  const reportError = useCallback((err: unknown) => {
+    const message = err instanceof Error ? err.message : String(err)
+    errorRef.current = true
+    setError(true)
+    setErrorMessage(message)
+    logger.error(message)
+    callbacks.current.onError?.()
   }, [])
 
-  useEffect(() => {
-    if (!player.current) return
+  const cancelObserve = useCallback(() => {
+    if (!observeId.current) return
+    cancelAnimationFrame(observeId.current)
+    observeId.current = 0
+  }, [])
 
-    const newPercentage = (time / audioDuration.current) * 100
-    setPercentage(newPercentage)
-  }, [time])
+  const resetPosition = useCallback(() => {
+    startTime.current = 0
+    pauseTime.current = 0
+    pickTime.current = 0
+    expectedEndTime.current = 0
+    setTime(0)
+    setPercentage(0)
+  }, [])
 
-  // Watch the audio play ended
-  useEffect(() => {
-    if (!player.current || error) return
-    if (!isPlaying || player.current.state === 'started') return
+  const completePlayback = useCallback(() => {
+    const currentPlayer = player.current
+    if (!currentPlayer || !completionArmed.current || loopRef.current) return
+    if (currentPlayer.immediate() + 0.02 < expectedEndTime.current) return
 
+    completionArmed.current = false
+    playingRef.current = false
+    startTime.current = 0
+    pauseTime.current = 0
+    pickTime.current = 0
+    expectedEndTime.current = 0
+    cancelObserve()
+    setIsPlaying(false)
+    setIsFinish(true)
+    setTime(audioDuration.current)
+    setPercentage(audioDuration.current > 0 ? 100 : 0)
+    callbacks.current.onFinish?.()
+  }, [cancelObserve])
+
+  const releasePlayer = useCallback(() => {
+    cancelObserve()
+    completionArmed.current = false
+    playingRef.current = false
+    const currentPlayer = player.current
+    player.current = null
+    if (!currentPlayer) return
     try {
-      setIsPlaying(false)
-      setIsFinish(true)
-      startTime.current = 0
-      pauseTime.current = 0
-      pickTime.current = 0
-      cancelObserve()
-      setTime(audioDuration.current)
-      onFinish?.()
-    } catch (err) {
-      setError(true)
-      setErrorMessage(err as string)
+      currentPlayer.onstop = () => undefined
+      currentPlayer.stop()
+    } catch {
+      // A source may already be stopped while React is performing cleanup.
     }
-  }, [player.current?.state])
+    currentPlayer.dispose()
+  }, [cancelObserve])
+
+  useEffect(() => releasePlayer, [releasePlayer])
 
   useEffect(() => {
-    if (!player.current || error) return
-
+    const currentPlayer = player.current
+    if (!currentPlayer || errorRef.current) return
     try {
-      player.current.loop = loop
-      player.current.mute = mute
-      player.current.volume.value = mute ? -Infinity : volume
+      currentPlayer.loop = loop
+      currentPlayer.mute = mute
+      currentPlayer.volume.value = mute ? -Infinity : volume
     } catch (err) {
-      setError(true)
-      setErrorMessage(err as string)
+      reportError(err)
     }
-  }, [player.current, volume, loop, mute])
+  }, [loop, mute, reportError, volume])
 
-  useEffect(() => {
-    if (!error) return
-    logger.error(errorMessage)
-    onError?.()
-  }, [error])
+  const init = useCallback(
+    (audioBuffer: AudioBuffer, chain: Tone.InputNode[] = []) => {
+      if (!audioBuffer) return
+      try {
+        releasePlayer()
+        resetPosition()
+        errorRef.current = false
+        setError(false)
+        setErrorMessage('')
+        setIsReady(false)
+        setIsPlaying(false)
+        setIsFinish(false)
+        audioDuration.current = audioBuffer.duration
 
-  const init = (audioBuffer: AudioBuffer, chain: Tone.InputNode[] = []) => {
-    if (!audioBuffer) return
-
-    try {
-      player.current = new Tone.Player(audioBuffer)
-      player.current.volume.value = volume
-      audioDuration.current = audioBuffer.duration
-      if (chain?.length) player.current.chain(...chain, Tone.Destination)
-      else player.current.toDestination()
-      setIsReady(true)
-      onReady?.()
-    } catch (err) {
-      setError(true)
-      setErrorMessage(err as string)
-    }
-  }
+        const nextPlayer = new Tone.Player(audioBuffer)
+        nextPlayer.onstop = completePlayback
+        nextPlayer.loop = loop
+        nextPlayer.mute = mute
+        nextPlayer.volume.value = mute ? -Infinity : volume
+        if (chain.length) nextPlayer.chain(...chain, Tone.Destination)
+        else nextPlayer.toDestination()
+        player.current = nextPlayer
+        setIsReady(nextPlayer.loaded)
+        callbacks.current.onReady?.()
+      } catch (err) {
+        reportError(err)
+      }
+    },
+    [completePlayback, loop, mute, releasePlayer, reportError, resetPosition, volume],
+  )
 
   const play = useCallback(() => {
-    if (!player.current || error) return
-
+    const currentPlayer = player.current
+    if (!currentPlayer || errorRef.current) return
     try {
-      if (isPlaying) player.current.stop()
-      const startOffset = pickTime.current ? pickTime.current : pauseTime.current
-      player.current.start(undefined, startOffset)
-      startTime.current = player.current.immediate() - startOffset
+      const duration = audioDuration.current
+      const startOffset = clamp(pickTime.current || pauseTime.current, 0, duration)
+      if (currentPlayer.state === 'started') currentPlayer.restart(undefined, startOffset)
+      else currentPlayer.start(undefined, startOffset)
+      const now = currentPlayer.immediate()
+      startTime.current = now - startOffset
+      expectedEndTime.current = now + Math.max(duration - startOffset, 0)
       pauseTime.current = 0
+      pickTime.current = 0
+      completionArmed.current = !loop
+      playingRef.current = true
       setIsPlaying(true)
       setIsFinish(false)
-      onPlay?.()
+      callbacks.current.onPlay?.()
     } catch (err) {
-      setError(true)
-      setErrorMessage(err as string)
+      reportError(err)
     }
-  }, [player.current, pickTime.current, pauseTime.current, error])
+  }, [loop, reportError])
 
   const pause = useCallback(() => {
-    if (!player.current || error) return
-
+    const currentPlayer = player.current
+    if (!currentPlayer || errorRef.current) return
     try {
-      player.current.stop()
-      const elapsed = (player.current.immediate() as number) - startTime.current
-      pauseTime.current = elapsed % audioDuration.current
+      const elapsed = currentPlayer.immediate() - startTime.current
+      const duration = audioDuration.current
+      const nextTime = loop && duration > 0 ? elapsed % duration : clamp(elapsed, 0, duration)
+      completionArmed.current = false
+      playingRef.current = false
+      currentPlayer.stop()
+      cancelObserve()
+      pauseTime.current = nextTime
       pickTime.current = 0
+      setTime(nextTime)
+      setPercentage(duration > 0 ? (nextTime / duration) * 100 : 0)
       setIsPlaying(false)
-      onPause?.()
+      callbacks.current.onPause?.()
     } catch (err) {
-      setError(true)
-      setErrorMessage(err as string)
+      reportError(err)
     }
-  }, [player.current, startTime.current, error])
+  }, [cancelObserve, loop, reportError])
 
   const stop = useCallback(() => {
-    if (!player.current || error) return
-
+    const currentPlayer = player.current
+    if (!currentPlayer || errorRef.current) return
     try {
-      player.current.stop()
-      setIsPlaying(false)
-      pauseTime.current = 0
-      startTime.current = 0
-      pickTime.current = 0
-      setTime(0)
-      onStop?.()
-    } catch (err) {
-      setError(true)
-      setErrorMessage(err as string)
-    }
-  }, [player.current, error])
-
-  const setPickTime = (time: number) => {
-    if (!player.current || error) return
-    pickTime.current = time
-
-    if (isPlaying) {
-      play()
+      completionArmed.current = false
+      playingRef.current = false
+      currentPlayer.stop()
       cancelObserve()
+      resetPosition()
+      setIsPlaying(false)
+      setIsFinish(false)
+      callbacks.current.onStop?.()
+    } catch (err) {
+      reportError(err)
     }
-  }
+  }, [cancelObserve, reportError, resetPosition])
 
   const getTime = useCallback(() => {
-    if (!player.current || error) return
-
+    const currentPlayer = player.current
+    if (!currentPlayer || errorRef.current) return
     try {
-      let newTime: number
-      // if paused, use the pauseTime
-      if (pauseTime.current) newTime = pauseTime.current
-      // if startTime is set, use the startTime
-      else if (startTime.current) newTime = player.current.immediate() - startTime.current
-      else newTime = player.current.immediate()
-
-      newTime = newTime % audioDuration.current
-      setTime(newTime)
+      const duration = audioDuration.current
+      let nextTime = pauseTime.current
+      if (playingRef.current) {
+        const elapsed = currentPlayer.immediate() - startTime.current
+        nextTime =
+          loopRef.current && duration > 0 ? elapsed % duration : clamp(elapsed, 0, duration)
+      }
+      setTime(nextTime)
+      setPercentage(duration > 0 ? (nextTime / duration) * 100 : 0)
+      if (currentPlayer.state === 'stopped') completePlayback()
     } catch (err) {
-      setError(true)
-      setErrorMessage(err as string)
+      reportError(err)
     }
-  }, [player.current, startTime.current, error])
+  }, [completePlayback, reportError])
 
   const observe = useCallback(() => {
-    if (!player.current || error) return
-
-    try {
+    if (!player.current || errorRef.current || observeId.current) return
+    const readFrame = () => {
       getTime()
-      observeId.current = requestAnimationFrame(observe)
-    } catch (err) {
-      setError(true)
-      setErrorMessage(err as string)
+      if (playingRef.current) observeId.current = requestAnimationFrame(readFrame)
+      else observeId.current = 0
     }
-  }, [getTime, error])
+    getTime()
+    observeId.current = requestAnimationFrame(readFrame)
+  }, [getTime])
 
-  const cancelObserve = () => {
-    if (!observeId.current) return
-
-    try {
-      cancelAnimationFrame(observeId.current)
-      observeId.current = 0
-    } catch (err) {
-      setError(true)
-      setErrorMessage(err as string)
-    }
-  }
+  const setPickTime = useCallback(
+    (nextTime: number) => {
+      const currentPlayer = player.current
+      if (!currentPlayer || errorRef.current) return
+      try {
+        const duration = audioDuration.current
+        const nextPosition = clamp(nextTime, 0, duration)
+        pickTime.current = nextPosition
+        pauseTime.current = nextPosition
+        setTime(nextPosition)
+        setPercentage(duration > 0 ? (nextPosition / duration) * 100 : 0)
+        if (playingRef.current) {
+          currentPlayer.restart(undefined, nextPosition)
+          const now = currentPlayer.immediate()
+          startTime.current = now - nextPosition
+          expectedEndTime.current = now + Math.max(duration - nextPosition, 0)
+          pickTime.current = 0
+          pauseTime.current = 0
+          completionArmed.current = !loopRef.current
+        }
+      } catch (err) {
+        reportError(err)
+      }
+    },
+    [reportError],
+  )
 
   return {
     player,

--- a/packages/hooks/useSpectrogram.ts
+++ b/packages/hooks/useSpectrogram.ts
@@ -39,19 +39,30 @@ export const useSpectrogram = (props: UseSpectrogramProps = {}) => {
   const [error, setError] = useState(false)
   const [errorMessage, setErrorMessage] = useState('')
 
-  const handleError = useCallback((err: unknown) => {
-    setError(true)
-    setErrorMessage(err as string)
-    logger.error(err as string)
-    onError?.()
-  }, [onError])
+  const handleError = useCallback(
+    (err: unknown) => {
+      setError(true)
+      setErrorMessage(err as string)
+      logger.error(err as string)
+      onError?.()
+    },
+    [onError],
+  )
 
-  useEffect(() => {
-    return () => {
-      analyser.current?.dispose()
-      cancelObserve()
-    }
+  const cancelObserve = useCallback(() => {
+    if (!observerId.current) return
+    cancelAnimationFrame(observerId.current)
+    observerId.current = 0
+    setData([])
   }, [])
+
+  const releaseAnalyser = useCallback(() => {
+    cancelObserve()
+    analyser.current?.dispose()
+    analyser.current = null
+  }, [cancelObserve])
+
+  useEffect(() => releaseAnalyser, [releaseAnalyser])
 
   useEffect(() => {
     if (!analyser.current || error) return
@@ -65,19 +76,26 @@ export const useSpectrogram = (props: UseSpectrogramProps = {}) => {
 
   const init = useCallback(() => {
     try {
+      releaseAnalyser()
       analyser.current = new Tone.Analyser('fft', fftSize)
       onReady?.()
     } catch (err) {
       handleError(err)
     }
-  }, [fftSize, handleError, onReady])
+  }, [fftSize, handleError, onReady, releaseAnalyser])
 
   const getData = useCallback(() => {
     if (!analyser.current || error) return
 
     try {
-      const spectrogramData = analyser.current.getValue()
-      if (spectrogramData instanceof Float32Array) {
+      const analyserValue: unknown = analyser.current.getValue()
+      const spectrogramData =
+        analyserValue instanceof Float32Array
+          ? analyserValue
+          : Array.isArray(analyserValue) && analyserValue[0] instanceof Float32Array
+            ? analyserValue[0]
+            : null
+      if (spectrogramData) {
         const formattedData = Array.from(spectrogramData).map((amplitude, frequency) => ({
           frequency,
           amplitude,
@@ -90,18 +108,15 @@ export const useSpectrogram = (props: UseSpectrogramProps = {}) => {
   }, [error, handleError])
 
   const observe = useCallback(() => {
-    if (!analyser.current || error) return
+    if (!analyser.current || error || observerId.current) return
 
-    getData()
-    observerId.current = requestAnimationFrame(observe)
-  }, [getData, error])
-
-  const cancelObserve = useCallback(() => {
-    if (observerId.current && !error) {
-      setData([])
-      cancelAnimationFrame(observerId.current)
+    const readFrame = () => {
+      getData()
+      observerId.current = requestAnimationFrame(readFrame)
     }
-  }, [error])
+    getData()
+    observerId.current = requestAnimationFrame(readFrame)
+  }, [getData, error])
 
   return {
     analyser,

--- a/packages/hooks/useVuMeter.ts
+++ b/packages/hooks/useVuMeter.ts
@@ -8,6 +8,15 @@ export interface UseVuMeterProps {
   onError?: () => void
 }
 
+const firstMeterValue = (value: unknown) => {
+  if (typeof value === 'number') return value
+  if (value instanceof Float32Array || Array.isArray(value)) {
+    const firstValue = value[0]
+    return typeof firstValue === 'number' ? firstValue : -Infinity
+  }
+  return -Infinity
+}
+
 /**
  * useVuMeter is a custom React hook that integrates with Tone.js to create a VU (Volume Unit) meter.
  * It can be used to monitor audio signal levels, supporting both mono and stereo inputs.
@@ -44,13 +53,26 @@ export const useVuMeter = (props: UseVuMeterProps) => {
   const [error, setError] = useState(false)
   const [errorMessage, setErrorMessage] = useState('')
 
-  useEffect(() => {
-    return () => {
-      if (!meter.current) return
-      meter.current.dispose()
-      cancelObserve()
-    }
-  }, [])
+  const cancelObserve = useCallback(() => {
+    if (!observerId.current) return
+    cancelAnimationFrame(observerId.current)
+    observerId.current = 0
+    setValue(_value)
+  }, [_value])
+
+  const releaseMeter = useCallback(() => {
+    cancelObserve()
+    meter.current?.dispose()
+    meterL.current?.dispose()
+    meterR.current?.dispose()
+    split.current?.dispose()
+    meter.current = null
+    meterL.current = null
+    meterR.current = null
+    split.current = null
+  }, [cancelObserve])
+
+  useEffect(() => releaseMeter, [releaseMeter])
 
   useEffect(() => {
     if (!error) return
@@ -60,6 +82,7 @@ export const useVuMeter = (props: UseVuMeterProps) => {
 
   const init = useCallback(() => {
     try {
+      releaseMeter()
       if (!isStereo) {
         meter.current = new Tone.Meter()
       } else {
@@ -74,7 +97,7 @@ export const useVuMeter = (props: UseVuMeterProps) => {
       setError(true)
       setErrorMessage(err as string)
     }
-  }, [])
+  }, [isStereo, onReady, releaseMeter])
 
   const getValue = useCallback(() => {
     if (error) return
@@ -82,37 +105,30 @@ export const useVuMeter = (props: UseVuMeterProps) => {
     if (isStereo && (!meterL.current || !meterR.current)) return
 
     try {
-      let newValue
-      if (isStereo) newValue = [meterL.current!.getValue(), meterR.current!.getValue()]
-      else newValue = meter.current!.getValue()
-      setValue(newValue as number | number[])
+      const newValue = isStereo
+        ? [firstMeterValue(meterL.current!.getValue()), firstMeterValue(meterR.current!.getValue())]
+        : firstMeterValue(meter.current!.getValue())
+      setValue(newValue)
     } catch (err) {
       setError(true)
       setErrorMessage(err as string)
     }
-  }, [])
+  }, [error, isStereo])
 
   const observe = useCallback(() => {
+    if (observerId.current || error) return
     try {
+      const readFrame = () => {
+        getValue()
+        observerId.current = requestAnimationFrame(readFrame)
+      }
       getValue()
-      observerId.current = requestAnimationFrame(observe)
+      observerId.current = requestAnimationFrame(readFrame)
     } catch (err) {
       setError(true)
       setErrorMessage(err as string)
     }
-  }, [])
-
-  const cancelObserve = useCallback(() => {
-    if (!observerId.current || error) return
-
-    try {
-      setValue(_value)
-      cancelAnimationFrame(observerId.current)
-    } catch (err) {
-      setError(true)
-      setErrorMessage(err as string)
-    }
-  }, [_value])
+  }, [error, getValue])
 
   return {
     meter: isStereo ? split : meter,

--- a/packages/hooks/useVuMeter.ts
+++ b/packages/hooks/useVuMeter.ts
@@ -17,6 +17,16 @@ const firstMeterValue = (value: unknown) => {
   return -Infinity
 }
 
+const stereoMeterValue = (value: unknown): number[] => {
+  if (typeof value === 'number') return [value, value]
+  if (value instanceof Float32Array || Array.isArray(value)) {
+    const left = typeof value[0] === 'number' ? value[0] : -Infinity
+    const right = typeof value[1] === 'number' ? value[1] : left
+    return [left, right]
+  }
+  return [-Infinity, -Infinity]
+}
+
 /**
  * useVuMeter is a custom React hook that integrates with Tone.js to create a VU (Volume Unit) meter.
  * It can be used to monitor audio signal levels, supporting both mono and stereo inputs.
@@ -27,7 +37,7 @@ const firstMeterValue = (value: unknown) => {
  * @param {Function} props.onError - Callback executed in case of an error.
  *
  * @returns {object} An object containing various properties and methods for the VU meter:
- * - meter: The Tone.js Meter or Split instance, depending on the input type (mono or stereo).
+ * - meter: The Tone.js Meter instance. Stereo mode uses Tone 15's multichannel Meter API.
  * - value: The current value(s) of the meter. It's a number for mono or an array of numbers for stereo.
  * - init: Method to initialize the VU meter.
  * - getValue: Method to retrieve the current value(s) from the meter.
@@ -44,10 +54,9 @@ export const useVuMeter = (props: UseVuMeterProps) => {
 
   const isStereo = Array.isArray(_value)
   const meter = useRef<Tone.Meter | null>(null)
-  const meterL = useRef<Tone.Meter | null>(null)
-  const meterR = useRef<Tone.Meter | null>(null)
-  const split = useRef<Tone.Split | null>(null)
   const observerId = useRef<number>(0)
+  const idleValue = useRef(_value)
+  idleValue.current = _value
 
   const [value, setValue] = useState(_value)
   const [error, setError] = useState(false)
@@ -57,19 +66,13 @@ export const useVuMeter = (props: UseVuMeterProps) => {
     if (!observerId.current) return
     cancelAnimationFrame(observerId.current)
     observerId.current = 0
-    setValue(_value)
-  }, [_value])
+    setValue(idleValue.current)
+  }, [])
 
   const releaseMeter = useCallback(() => {
     cancelObserve()
     meter.current?.dispose()
-    meterL.current?.dispose()
-    meterR.current?.dispose()
-    split.current?.dispose()
     meter.current = null
-    meterL.current = null
-    meterR.current = null
-    split.current = null
   }, [cancelObserve])
 
   useEffect(() => releaseMeter, [releaseMeter])
@@ -78,20 +81,12 @@ export const useVuMeter = (props: UseVuMeterProps) => {
     if (!error) return
     logger.error(errorMessage)
     onError?.()
-  }, [error])
+  }, [error, errorMessage, onError])
 
   const init = useCallback(() => {
     try {
       releaseMeter()
-      if (!isStereo) {
-        meter.current = new Tone.Meter()
-      } else {
-        meterL.current = new Tone.Meter()
-        meterR.current = new Tone.Meter()
-        split.current = new Tone.Split()
-        split.current.connect(meterL.current, 0)
-        split.current.connect(meterR.current, 1)
-      }
+      meter.current = new Tone.Meter({ channelCount: isStereo ? 2 : 1 })
       onReady?.()
     } catch (err) {
       setError(true)
@@ -101,13 +96,11 @@ export const useVuMeter = (props: UseVuMeterProps) => {
 
   const getValue = useCallback(() => {
     if (error) return
-    if (!isStereo && !meter.current) return
-    if (isStereo && (!meterL.current || !meterR.current)) return
+    if (!meter.current) return
 
     try {
-      const newValue = isStereo
-        ? [firstMeterValue(meterL.current!.getValue()), firstMeterValue(meterR.current!.getValue())]
-        : firstMeterValue(meter.current!.getValue())
+      const meterValue = meter.current.getValue()
+      const newValue = isStereo ? stereoMeterValue(meterValue) : firstMeterValue(meterValue)
       setValue(newValue)
     } catch (err) {
       setError(true)
@@ -131,7 +124,7 @@ export const useVuMeter = (props: UseVuMeterProps) => {
   }, [error, getValue])
 
   return {
-    meter: isStereo ? split : meter,
+    meter,
     value,
     init,
     getValue,

--- a/packages/hooks/useWaveform.ts
+++ b/packages/hooks/useWaveform.ts
@@ -10,89 +10,59 @@ export interface UseWaveformProps {
 const CHANNEL = 2
 const SAMPLES = 512 * 2
 
+const simplifyData = (rawData: Float32Array, requestedSamples: number) => {
+  const sampleCount = Math.max(1, Math.floor(requestedSamples))
+  if (rawData.length === 0) return Array.from({ length: sampleCount }, () => 0)
+
+  return Array.from({ length: sampleCount }, (_, index) => {
+    const start = Math.min(Math.floor((index * rawData.length) / sampleCount), rawData.length - 1)
+    const end = Math.min(
+      Math.max(start + 1, Math.floor(((index + 1) * rawData.length) / sampleCount)),
+      rawData.length,
+    )
+    let sum = 0
+    for (let cursor = start; cursor < end; cursor += 1) sum += Math.abs(rawData[cursor])
+    return sum / (end - start)
+  })
+}
+
 /**
- * useWaveform is a custom React hook that processes an audio buffer to generate waveform data.
- * This hook simplifies the raw audio data into a set of samples, which can be used for visualizing
- * the audio waveform in a user interface.
- *
- * @param {UseWaveformProps} props - The configuration properties for the waveform processing.
- * @param {AudioBuffer | null} props.audioBuffer - The audio buffer containing the raw audio data to be processed.
- * @param {1 | 2} [props.channel=2] - The channel number to be processed (1 for mono, 2 for stereo). Defaults to 2 (stereo).
- * @param {number} [props.samples=1024] - The number of samples to be generated from the audio data. Defaults to 1024.
- *
- * @returns {object} An object containing the waveform data and any error information:
- * - data: An array of numbers (for mono) or an array of arrays of numbers (for stereo), representing the simplified waveform data.
- * - audioDuration: A ref object containing the duration of the audio in seconds.
- * - error: A boolean indicating if an error has occurred during processing.
- * - errorMessage: A string containing the error message if an error has occurred.
- *
- * This hook is useful for applications that require audio visualization, such as audio players,
- * editors, or any application dealing with audio data analysis.
+ * Reduces the available channels of an AudioBuffer into a fixed number of finite waveform samples.
  */
 export const useWaveform = (props: UseWaveformProps) => {
   const { audioBuffer, channel = CHANNEL, samples = SAMPLES } = props
 
-  const [data, setData] = useState<number[][] | number[]>([])
+  const [data, setData] = useState<number[][]>([])
   const audioDuration = useRef(0)
   const [error, setError] = useState(false)
   const [errorMessage, setErrorMessage] = useState('')
 
   useEffect(() => {
-    if (data.length) return
-    loadAndDecodeAudio()
-    getAudioDuration()
-  }, [channel, samples, audioBuffer])
+    if (!audioBuffer) {
+      audioDuration.current = 0
+      setData([])
+      return
+    }
+
+    try {
+      const availableChannels = Math.min(channel, audioBuffer.numberOfChannels)
+      const nextData = Array.from({ length: availableChannels }, (_, channelIndex) =>
+        simplifyData(audioBuffer.getChannelData(channelIndex), samples),
+      )
+      audioDuration.current = audioBuffer.duration
+      setData(nextData)
+      setError(false)
+      setErrorMessage('')
+    } catch (err) {
+      setData([])
+      setError(true)
+      setErrorMessage(err instanceof Error ? err.message : String(err))
+    }
+  }, [audioBuffer, channel, samples])
 
   useEffect(() => {
     if (error) logger.error(errorMessage)
-  }, [error])
-
-  const getAudioDuration = () => {
-    if (error || !audioBuffer) return
-
-    try {
-      audioDuration.current = audioBuffer.duration
-    } catch (err) {
-      setError(true)
-      setErrorMessage(err as string)
-    }
-  }
-
-  const loadAndDecodeAudio = async () => {
-    if (error || !audioBuffer) return
-
-    try {
-      const channelData =
-        channel === 1
-          ? [audioBuffer.getChannelData(0)]
-          : [audioBuffer.getChannelData(0), audioBuffer.getChannelData(1)]
-      const simplifiedData = channelData.map((data) => simplifyData(data)) as number[][]
-      setData(simplifiedData)
-    } catch (err) {
-      setError(true)
-      setErrorMessage(err as string)
-    }
-  }
-
-  const simplifyData = (rawData: Float32Array) => {
-    if (error) return
-
-    try {
-      const blockSize = Math.floor(rawData.length / samples)
-      const simplifiedData = []
-      for (let i = 0; i < samples; i++) {
-        let sum = 0
-        for (let j = 0; j < blockSize; j++) {
-          sum += Math.abs(rawData[blockSize * i + j])
-        }
-        simplifiedData.push(sum / blockSize)
-      }
-      return simplifiedData
-    } catch (err) {
-      setError(true)
-      setErrorMessage(err as string)
-    }
-  }
+  }, [error, errorMessage])
 
   return { data, audioDuration, error, errorMessage }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,8 +21,8 @@ importers:
         specifier: ^3.2.2
         version: 3.2.2(tailwind-merge@3.6.0)(tailwindcss@4.3.3)
       tone:
-        specifier: ^14.7.77
-        version: 14.9.17
+        specifier: ^15.1.22
+        version: 15.1.22
     devDependencies:
       '@playwright/test':
         specifier: 1.51.1
@@ -146,8 +146,8 @@ importers:
         specifier: 19.2.8
         version: 19.2.8(react@19.2.8)
       tone:
-        specifier: ^14.7.77
-        version: 14.9.17
+        specifier: ^15.1.22
+        version: 15.1.22
     devDependencies:
       '@tailwindcss/vite':
         specifier: 4.3.3
@@ -3073,8 +3073,8 @@ packages:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
 
-  tone@14.9.17:
-    resolution: {integrity: sha512-+Qb7M4NMua+tb5Z52+MEVmjye0fjJuIFBePx423pqr9E6/lHDqZAG+fUAvo+Ujm48q0s9bVLRAyT1ETJJglNtg==}
+  tone@15.1.22:
+    resolution: {integrity: sha512-TCScAGD4sLsama5DjvTUXlLDXSqPealhL64nsdV1hhr6frPWve0DeSo63AKnSJwgfg55fhvxj0iPPRwPN5o0ag==}
 
   tough-cookie@6.0.2:
     resolution: {integrity: sha512-exgYmnmL/sJpR3upZfXG5PoatXQii55xAiXGXzY+sROLZ/Y+SLcp9PgJNI9Vz37HpQ74WvDcLT8eqm+kV3FzrA==}
@@ -6767,7 +6767,7 @@ snapshots:
     dependencies:
       is-number: 7.0.0
 
-  tone@14.9.17:
+  tone@15.1.22:
     dependencies:
       standardized-audio-context: 25.3.77
       tslib: 2.8.1

--- a/scripts/smoke-nextra-routes.mjs
+++ b/scripts/smoke-nextra-routes.mjs
@@ -350,7 +350,7 @@ try {
       const route = `${basePath}/${locale}/hook/${hook}/`
       await runComponentRoute({
         allowedBrowserErrors: [
-          /^Echo UI: (?:Error: )?Not Found/,
+          /^Echo UI: Error: Not Found/,
           /^Failed to load resource: the server responded with a status of 404/,
         ],
         apiSelector: `[data-hook-api="${hook}"]`,

--- a/scripts/smoke-nextra-routes.mjs
+++ b/scripts/smoke-nextra-routes.mjs
@@ -350,7 +350,7 @@ try {
       const route = `${basePath}/${locale}/hook/${hook}/`
       await runComponentRoute({
         allowedBrowserErrors: [
-          /^Echo UI: Error: Not Found/,
+          /^Echo UI: (?:Error: )?Not Found/,
           /^Failed to load resource: the server responded with a status of 404/,
         ],
         apiSelector: `[data-hook-api="${hook}"]`,

--- a/scripts/smoke-react-consumers.mjs
+++ b/scripts/smoke-react-consumers.mjs
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict'
 import { execFileSync } from 'node:child_process'
-import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises'
+import { mkdtemp, mkdir, readFile, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join, resolve } from 'node:path'
 import { packLocalPackage } from './pack-local-package.mjs'
@@ -37,6 +37,7 @@ try {
             '@nafr/echo-ui': `file:${archivePath}`,
             react: reactVersion,
             'react-dom': reactVersion,
+            tone: '15.1.22',
           },
           devDependencies: {
             '@types/react': reactTypesVersion,
@@ -52,11 +53,19 @@ try {
     await writeFile(
       join(consumerDirectory, 'consumer.tsx'),
       `import { useRef } from 'react'
-import { Button, useFetchAudio } from '@nafr/echo-ui'
+import { Button, useFetchAudio, usePlayer } from '@nafr/echo-ui'
+import type { InputNode, Player } from 'tone'
 
 export function Consumer() {
   const buttonRef = useRef<HTMLButtonElement>(null)
   const { pending } = useFetchAudio({ url: '/consumer.wav' })
+  const echoPlayer = usePlayer()
+  const tonePlayer: Player | null = echoPlayer.player.current
+  const chain: InputNode[] = []
+  const initPlayer: (audioBuffer: AudioBuffer, chain?: InputNode[]) => void = echoPlayer.init
+  void tonePlayer
+  void chain
+  void initPlayer
   return <Button ref={buttonRef}>{pending ? 'Loading' : 'Ready'}</Button>
 }
 `,
@@ -89,6 +98,7 @@ import { createRoot } from 'react-dom/client'
 import { renderToStaticMarkup } from 'react-dom/server'
 import { Button, useFetchAudio } from '@nafr/echo-ui'
 import { JSDOM } from 'jsdom'
+import { version as toneVersion } from 'tone'
 
 let fetchAudio
 let onErrorCalls = 0
@@ -173,7 +183,7 @@ await act(async () => {
 })
 assert.ok(refDetachCalls >= 1)
 
-console.log(JSON.stringify({ markup, reactDomVersion, reactVersion }))
+console.log(JSON.stringify({ markup, reactDomVersion, reactVersion, toneVersion }))
 `,
     )
 
@@ -182,6 +192,15 @@ console.log(JSON.stringify({ markup, reactDomVersion, reactVersion }))
       ['install', '--frozen-lockfile=false', '--ignore-scripts', '--strict-peer-dependencies'],
       { cwd: consumerDirectory, stdio: 'pipe' },
     )
+    const installedPackageRoot = join(consumerDirectory, 'node_modules', '@nafr', 'echo-ui')
+    const [installedManifest, esmBundle, umdBundle] = await Promise.all([
+      readFile(join(installedPackageRoot, 'package.json'), 'utf8').then(JSON.parse),
+      readFile(join(installedPackageRoot, 'dist', 'echo-ui.js'), 'utf8'),
+      readFile(join(installedPackageRoot, 'dist', 'echo-ui.umd.cjs'), 'utf8'),
+    ])
+    assert.equal(installedManifest.dependencies.tone, '^15.1.22')
+    assert.match(esmBundle, /from ["']tone["']/)
+    assert.match(umdBundle, /require\(["']tone["']\)/)
     execFileSync('pnpm', ['exec', 'tsc'], { cwd: consumerDirectory, stdio: 'pipe' })
     const result = JSON.parse(
       execFileSync(process.execPath, ['render.mjs'], {
@@ -192,6 +211,7 @@ console.log(JSON.stringify({ markup, reactDomVersion, reactVersion }))
 
     assert.equal(result.reactVersion, reactVersion)
     assert.equal(result.reactDomVersion, reactVersion)
+    assert.equal(result.toneVersion, '15.1.22')
     console.log(`React ${reactVersion} consumer installed and rendered Echo UI.`)
   }
 } finally {

--- a/scripts/smoke-react-consumers.mjs
+++ b/scripts/smoke-react-consumers.mjs
@@ -53,8 +53,15 @@ try {
     await writeFile(
       join(consumerDirectory, 'consumer.tsx'),
       `import { useRef } from 'react'
-import { Button, useFetchAudio, usePlayer } from '@nafr/echo-ui'
-import type { InputNode, Player } from 'tone'
+import {
+  Button,
+  useFetchAudio,
+  useOscilloscope,
+  usePlayer,
+  useSpectrogram,
+  useVuMeter,
+} from '@nafr/echo-ui'
+import type { Analyser, InputNode, Meter, Player } from 'tone'
 
 export function Consumer() {
   const buttonRef = useRef<HTMLButtonElement>(null)
@@ -63,9 +70,18 @@ export function Consumer() {
   const tonePlayer: Player | null = echoPlayer.player.current
   const chain: InputNode[] = []
   const initPlayer: (audioBuffer: AudioBuffer, chain?: InputNode[]) => void = echoPlayer.init
+  const oscilloscope = useOscilloscope()
+  const spectrogram = useSpectrogram()
+  const vuMeter = useVuMeter({ value: [-60, -60] })
+  const oscilloscopeNode: Analyser | null = oscilloscope.analyser.current
+  const spectrogramNode: Analyser | null = spectrogram.analyser.current
+  const meterNode: Meter | null = vuMeter.meter.current
   void tonePlayer
   void chain
   void initPlayer
+  void oscilloscopeNode
+  void spectrogramNode
+  void meterNode
   return <Button ref={buttonRef}>{pending ? 'Loading' : 'Ready'}</Button>
 }
 `,

--- a/scripts/smoke-tone-examples.mjs
+++ b/scripts/smoke-tone-examples.mjs
@@ -40,12 +40,16 @@ assert.ok(address && typeof address === 'object')
 
 const launchBrowser = async () => {
   const channel = process.env.PLAYWRIGHT_CHANNEL
-  if (channel) return chromium.launch({ channel, headless: true })
+  const options = {
+    args: ['--use-fake-device-for-media-stream', '--use-fake-ui-for-media-stream'],
+    headless: true,
+  }
+  if (channel) return chromium.launch({ ...options, channel })
   try {
-    return await chromium.launch({ headless: true })
+    return await chromium.launch(options)
   } catch (bundledBrowserError) {
     try {
-      return await chromium.launch({ channel: 'chrome', headless: true })
+      return await chromium.launch({ ...options, channel: 'chrome' })
     } catch {
       throw new Error(
         'Playwright could not launch Chromium or Chrome. Run `pnpm exec playwright install chromium` or set PLAYWRIGHT_CHANNEL.',
@@ -111,11 +115,87 @@ try {
     { timeout: 3_000 },
   )
 
+  const exerciseToggle = async ({ example, startName, stopName }) => {
+    const demo = page.locator(`[data-audio-example="${example}"]`)
+    await demo.waitFor({ state: 'visible' })
+    await page.waitForFunction(
+      ({ exampleName, name }) => {
+        const section = document.querySelector(`[data-audio-example="${exampleName}"]`)
+        const button = [...(section?.querySelectorAll('button') ?? [])].find(
+          (candidate) => candidate.getAttribute('aria-label') === name,
+        )
+        return button instanceof HTMLButtonElement && !button.disabled
+      },
+      { exampleName: example, name: startName },
+      { timeout: 5_000 },
+    )
+    await demo.getByRole('button', { name: startName }).click()
+    await page.waitForFunction(
+      (exampleName) =>
+        document
+          .querySelector(`[data-audio-example="${exampleName}"]`)
+          ?.getAttribute('data-audio-state') !== 'stopped',
+      example,
+    )
+    await demo.getByRole('button', { name: stopName }).click()
+    await page.waitForFunction(
+      (exampleName) =>
+        document
+          .querySelector(`[data-audio-example="${exampleName}"]`)
+          ?.getAttribute('data-audio-state') === 'stopped',
+      example,
+    )
+  }
+
+  await exerciseToggle({
+    example: 'spectrogram-filtered',
+    startName: 'Start filtered spectrogram',
+    stopName: 'Stop filtered spectrogram',
+  })
+  await exerciseToggle({
+    example: 'spectrogram-default',
+    startName: 'Start default spectrogram',
+    stopName: 'Stop default spectrogram',
+  })
+  await exerciseToggle({
+    example: 'vu-stereo',
+    startName: 'Start stereo VU',
+    stopName: 'Pause stereo VU',
+  })
+  await exerciseToggle({
+    example: 'vu-mono',
+    startName: 'Start mono VU',
+    stopName: 'Pause mono VU',
+  })
+  await exerciseToggle({
+    example: 'player-meter-slider',
+    startName: 'Start player meter',
+    stopName: 'Stop player meter',
+  })
+  await exerciseToggle({
+    example: 'oscilloscope',
+    startName: 'Start oscilloscope',
+    stopName: 'Stop oscilloscope',
+  })
+  await exerciseToggle({
+    example: 'waveform',
+    startName: 'Start waveform',
+    stopName: 'Pause waveform',
+  })
+  await exerciseToggle({
+    example: 'microphone-vu',
+    startName: 'Start microphone VU',
+    stopName: 'Stop microphone VU',
+  })
+
+  await page.waitForTimeout(300)
+
   assert.deepEqual(browserErrors, [])
+  await page.goto('about:blank')
   await page.close()
 } finally {
   await browser?.close()
   await new Promise((resolveClose) => server.close(resolveClose))
 }
 
-console.log('Tone 15 LFO and envelope examples passed real-browser lifecycle smoke.')
+console.log('Tone 15 migrated examples passed real-browser interaction and lifecycle smoke.')

--- a/scripts/smoke-tone-examples.mjs
+++ b/scripts/smoke-tone-examples.mjs
@@ -1,0 +1,121 @@
+import assert from 'node:assert/strict'
+import { createReadStream } from 'node:fs'
+import { stat } from 'node:fs/promises'
+import { createServer } from 'node:http'
+import { extname, resolve, sep } from 'node:path'
+import { chromium } from '@playwright/test'
+
+const outputRoot = resolve(import.meta.dirname, '..', 'example', 'dist')
+const contentTypes = {
+  '.css': 'text/css; charset=utf-8',
+  '.html': 'text/html; charset=utf-8',
+  '.js': 'text/javascript; charset=utf-8',
+  '.svg': 'image/svg+xml',
+  '.wav': 'audio/wav',
+}
+
+const server = createServer(async (request, response) => {
+  try {
+    const pathname = decodeURIComponent(new URL(request.url ?? '/', 'http://localhost').pathname)
+    const relativePath = pathname.replace(/^\/+/, '') || 'index.html'
+    let outputFile = resolve(outputRoot, relativePath)
+    assert.ok(outputFile === outputRoot || outputFile.startsWith(`${outputRoot}${sep}`))
+    const fileStats = await stat(outputFile)
+    if (fileStats.isDirectory()) outputFile = resolve(outputFile, 'index.html')
+    response.writeHead(200, {
+      'Content-Type': contentTypes[extname(outputFile)] ?? 'application/octet-stream',
+    })
+    createReadStream(outputFile).pipe(response)
+  } catch {
+    response.writeHead(404)
+    response.end('Not found')
+  }
+})
+
+const address = await new Promise((resolveListen, reject) => {
+  server.once('error', reject)
+  server.listen(0, '127.0.0.1', () => resolveListen(server.address()))
+})
+assert.ok(address && typeof address === 'object')
+
+const launchBrowser = async () => {
+  const channel = process.env.PLAYWRIGHT_CHANNEL
+  if (channel) return chromium.launch({ channel, headless: true })
+  try {
+    return await chromium.launch({ headless: true })
+  } catch (bundledBrowserError) {
+    try {
+      return await chromium.launch({ channel: 'chrome', headless: true })
+    } catch {
+      throw new Error(
+        'Playwright could not launch Chromium or Chrome. Run `pnpm exec playwright install chromium` or set PLAYWRIGHT_CHANNEL.',
+        { cause: bundledBrowserError },
+      )
+    }
+  }
+}
+
+let browser
+try {
+  browser = await launchBrowser()
+  const page = await browser.newPage()
+  const browserErrors = []
+  page.on('pageerror', (error) => browserErrors.push(error.message))
+  await page.goto(`http://127.0.0.1:${address.port}`, { waitUntil: 'domcontentloaded' })
+
+  const lfo = page.locator('[data-audio-example="lfo"]')
+  await lfo.waitFor({ state: 'visible' })
+  assert.equal(await lfo.getAttribute('data-tone-version'), '15.1.22')
+  for (let cycle = 0; cycle < 2; cycle += 1) {
+    await lfo.getByRole('button', { name: 'Start LFO' }).click()
+    await page.waitForFunction(
+      () =>
+        document.querySelector('[data-audio-example="lfo"]')?.getAttribute('data-audio-state') ===
+        'playing',
+    )
+    assert.equal(await lfo.getAttribute('data-audio-state'), 'playing')
+    await lfo.getByRole('button', { name: 'Stop LFO' }).click()
+    assert.equal(await lfo.getAttribute('data-audio-state'), 'stopped')
+  }
+
+  const adsr = page.locator('[data-audio-example="envelope-adsr"]')
+  const adsrTrigger = adsr.getByRole('button', { name: 'Hold ADSR envelope' })
+  for (let cycle = 0; cycle < 2; cycle += 1) {
+    await adsrTrigger.dispatchEvent('mousedown')
+    await page.waitForFunction(
+      () =>
+        document
+          .querySelector('[data-audio-example="envelope-adsr"]')
+          ?.getAttribute('data-audio-state') === 'playing',
+    )
+    await adsrTrigger.dispatchEvent('mouseup')
+    assert.equal(await adsr.getAttribute('data-audio-state'), 'stopped')
+  }
+
+  const ahdsr = page.locator('[data-audio-example="envelope-ahdsr"]')
+  const ahdsrTrigger = ahdsr.getByRole('button', { name: 'Trigger AHDSR envelope' })
+  await ahdsrTrigger.dispatchEvent('mousedown')
+  await page.waitForFunction(
+    () =>
+      document
+        .querySelector('[data-audio-example="envelope-ahdsr"]')
+        ?.getAttribute('data-audio-state') === 'scheduled',
+  )
+  await ahdsrTrigger.dispatchEvent('mousedown')
+  await page.waitForFunction(
+    () =>
+      document
+        .querySelector('[data-audio-example="envelope-ahdsr"]')
+        ?.getAttribute('data-audio-state') === 'stopped',
+    undefined,
+    { timeout: 3_000 },
+  )
+
+  assert.deepEqual(browserErrors, [])
+  await page.close()
+} finally {
+  await browser?.close()
+  await new Promise((resolveClose) => server.close(resolveClose))
+}
+
+console.log('Tone 15 LFO and envelope examples passed real-browser lifecycle smoke.')

--- a/scripts/smoke-tone-hooks.mjs
+++ b/scripts/smoke-tone-hooks.mjs
@@ -65,6 +65,16 @@ try {
   await page.goto(origin, { waitUntil: 'networkidle' })
   await page.locator('[data-tone-harness="ready"]').waitFor()
 
+  const scheduling = await page.evaluate(() => window.__echoToneHarness.scheduling())
+  assert.equal(scheduling.contextState, 'running')
+  assert.ok(scheduling.beforeAttack < 0.05)
+  assert.ok(scheduling.peak > 0.9)
+  assert.ok(scheduling.sustain > 0.4 && scheduling.sustain < 0.6)
+  assert.ok(scheduling.afterRelease < 0.05)
+  assert.ok(scheduling.lfoBeforeVariance < 0.0001)
+  assert.ok(scheduling.lfoActiveVariance > 0.01)
+  assert.ok(scheduling.lfoAfterVariance < 0.0001)
+
   await page.evaluate(() => window.__echoToneHarness.initPlayer(0.5, 0.25))
   let playerState = await page.evaluate(() => window.__echoToneHarness.player())
   assert.equal(playerState.toneVersion, '15.1.22')
@@ -136,6 +146,7 @@ try {
   await page.waitForFunction(
     () =>
       window.__echoReleasedNodes.every((node) => node.disposed) &&
+      window.__echoDisposedMeterCount() >= 2 &&
       window.__echoActiveAnimationFrames() === 0,
   )
   assert.deepEqual(browserErrors, [])

--- a/scripts/smoke-tone-hooks.mjs
+++ b/scripts/smoke-tone-hooks.mjs
@@ -1,0 +1,148 @@
+import assert from 'node:assert/strict'
+import { resolve } from 'node:path'
+import { chromium } from '@playwright/test'
+import react from '@vitejs/plugin-react'
+import { createServer } from 'vite'
+
+const packageRoot = resolve(import.meta.dirname, '..')
+const fixtureRoot = resolve(packageRoot, 'tests', 'fixtures', 'tone-browser')
+const server = await createServer({
+  configFile: false,
+  logLevel: 'error',
+  plugins: [react()],
+  resolve: {
+    alias: { '@nafr/echo-ui': resolve(packageRoot, 'dist', 'echo-ui.js') },
+  },
+  root: fixtureRoot,
+  server: { host: '127.0.0.1', port: 0 },
+})
+
+const launchBrowser = async () => {
+  const channel = process.env.PLAYWRIGHT_CHANNEL
+  if (channel) return chromium.launch({ channel, headless: true })
+  try {
+    return await chromium.launch({ headless: true })
+  } catch (bundledBrowserError) {
+    try {
+      return await chromium.launch({ channel: 'chrome', headless: true })
+    } catch {
+      throw new Error(
+        'Playwright could not launch Chromium or Chrome. Run `pnpm exec playwright install chromium` or set PLAYWRIGHT_CHANNEL.',
+        { cause: bundledBrowserError },
+      )
+    }
+  }
+}
+
+let browser
+try {
+  await server.listen()
+  const origin = server.resolvedUrls?.local[0]
+  assert.ok(origin)
+  browser = await launchBrowser()
+  const page = await browser.newPage()
+  const browserErrors = []
+  page.on('pageerror', (error) => browserErrors.push(error.message))
+  await page.addInitScript(() => {
+    const activeFrames = new Set()
+    const requestFrame = window.requestAnimationFrame.bind(window)
+    const cancelFrame = window.cancelAnimationFrame.bind(window)
+    window.requestAnimationFrame = (callback) => {
+      let frameId = 0
+      frameId = requestFrame((time) => {
+        activeFrames.delete(frameId)
+        callback(time)
+      })
+      activeFrames.add(frameId)
+      return frameId
+    }
+    window.cancelAnimationFrame = (frameId) => {
+      activeFrames.delete(frameId)
+      cancelFrame(frameId)
+    }
+    window.__echoActiveAnimationFrames = () => activeFrames.size
+  })
+  await page.goto(origin, { waitUntil: 'networkidle' })
+  await page.locator('[data-tone-harness="ready"]').waitFor()
+
+  await page.evaluate(() => window.__echoToneHarness.initPlayer(0.5, 0.25))
+  let playerState = await page.evaluate(() => window.__echoToneHarness.player())
+  assert.equal(playerState.toneVersion, '15.1.22')
+  assert.equal(playerState.instanceOfConsumerTone, true)
+
+  await page.evaluate(() => window.__echoToneHarness.playPlayer())
+  await page.waitForTimeout(80)
+  await page.evaluate(() => window.__echoToneHarness.pausePlayer())
+  playerState = await page.evaluate(() => window.__echoToneHarness.player())
+  assert.ok(playerState.time > 0 && playerState.time < 0.5)
+  const pausedAt = playerState.time
+  await page.waitForTimeout(60)
+  assert.ok(
+    Math.abs((await page.evaluate(() => window.__echoToneHarness.player())).time - pausedAt) < 0.03,
+  )
+
+  await page.evaluate(() => window.__echoToneHarness.playPlayer())
+  await page.evaluate(() => window.__echoToneHarness.seekPlayer(0.3))
+  await page.waitForTimeout(40)
+  playerState = await page.evaluate(() => window.__echoToneHarness.player())
+  assert.ok(playerState.time >= 0.3)
+  assert.ok(playerState.percentage >= 60)
+  await page.evaluate(() => window.__echoToneHarness.stopPlayer())
+  playerState = await page.evaluate(() => window.__echoToneHarness.player())
+  assert.equal(playerState.time, 0)
+  assert.equal(playerState.percentage, 0)
+
+  await page.evaluate(() => window.__echoToneHarness.initPlayer(0.08, 0.5))
+  assert.equal(
+    (await page.evaluate(() => window.__echoToneHarness.player())).disposedReplacedPlayers,
+    true,
+  )
+  await page.evaluate(() => window.__echoToneHarness.playPlayer())
+  await page.waitForFunction(() => window.__echoToneHarness.player().isFinish, undefined, {
+    timeout: 2_000,
+  })
+  playerState = await page.evaluate(() => window.__echoToneHarness.player())
+  assert.equal(playerState.percentage, 100)
+
+  await page.evaluate(() => window.__echoToneHarness.initAnalysis())
+  await page.waitForFunction(
+    () => {
+      const analysis = window.__echoToneHarness.analysis()
+      return analysis.oscilloscopeSamples > 0 && analysis.spectrogramSamples > 0
+    },
+    undefined,
+    { timeout: 2_000 },
+  )
+  const analysis = await page.evaluate(() => window.__echoToneHarness.analysis())
+  assert.equal(analysis.contextState, 'running')
+  assert.ok(typeof analysis.meter === 'number' && !Number.isNaN(analysis.meter))
+  assert.ok(
+    Array.isArray(analysis.stereoMeter) &&
+      analysis.stereoMeter.every((value) => typeof value === 'number' && !Number.isNaN(value)),
+  )
+
+  await page.evaluate(() => window.__echoToneHarness.setWaveform(1, 0.25))
+  await page.waitForFunction(() => window.__echoToneHarness.waveform().length === 1)
+  let waveform = await page.evaluate(() => window.__echoToneHarness.waveform())
+  assert.ok(waveform.flat().every(Number.isFinite))
+  await page.evaluate(() => window.__echoToneHarness.setWaveform(2, 0.5))
+  await page.waitForFunction(() => window.__echoToneHarness.waveform().length === 2)
+  waveform = await page.evaluate(() => window.__echoToneHarness.waveform())
+  assert.equal(waveform[0][0], 0.5)
+  assert.equal(waveform[1][0], 1)
+
+  await page.evaluate(() => window.__echoToneHarness.release())
+  await page.getByText('released').waitFor()
+  await page.waitForFunction(
+    () =>
+      window.__echoReleasedNodes.every((node) => node.disposed) &&
+      window.__echoActiveAnimationFrames() === 0,
+  )
+  assert.deepEqual(browserErrors, [])
+  await page.close()
+} finally {
+  await browser?.close()
+  await server.close()
+}
+
+console.log('Echo UI hooks passed Tone 15 real-browser behavior and lifecycle smoke.')

--- a/tests/fixtures/package-consumer.ts
+++ b/tests/fixtures/package-consumer.ts
@@ -1,13 +1,26 @@
-import { Button, useFetchAudio, usePlayer } from '@nafr/echo-ui'
-import type { InputNode, Player } from 'tone'
+import {
+  Button,
+  useFetchAudio,
+  useOscilloscope,
+  usePlayer,
+  useSpectrogram,
+  useVuMeter,
+} from '@nafr/echo-ui'
+import type { Analyser, InputNode, Meter, Player } from 'tone'
 
 export const PackageButton = Button
 export const usePackageAudio = useFetchAudio
 
 export const useTonePlayerContract = () => {
   const echoPlayer = usePlayer()
+  const oscilloscope = useOscilloscope()
+  const spectrogram = useSpectrogram()
+  const vuMeter = useVuMeter({ value: [-60, -60] })
   const player: Player | null = echoPlayer.player.current
+  const oscilloscopeNode: Analyser | null = oscilloscope.analyser.current
+  const spectrogramNode: Analyser | null = spectrogram.analyser.current
+  const meterNode: Meter | null = vuMeter.meter.current
   const chain: InputNode[] = []
   echoPlayer.init({} as AudioBuffer, chain)
-  return player
+  return { meterNode, oscilloscopeNode, player, spectrogramNode }
 }

--- a/tests/fixtures/package-consumer.ts
+++ b/tests/fixtures/package-consumer.ts
@@ -1,4 +1,13 @@
-import { Button, useFetchAudio } from '@nafr/echo-ui'
+import { Button, useFetchAudio, usePlayer } from '@nafr/echo-ui'
+import type { InputNode, Player } from 'tone'
 
 export const PackageButton = Button
 export const usePackageAudio = useFetchAudio
+
+export const useTonePlayerContract = () => {
+  const echoPlayer = usePlayer()
+  const player: Player | null = echoPlayer.player.current
+  const chain: InputNode[] = []
+  echoPlayer.init({} as AudioBuffer, chain)
+  return player
+}

--- a/tests/fixtures/tone-browser/index.html
+++ b/tests/fixtures/tone-browser/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Echo UI Tone 15 browser contract</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/main.tsx"></script>
+  </body>
+</html>

--- a/tests/fixtures/tone-browser/main.tsx
+++ b/tests/fixtures/tone-browser/main.tsx
@@ -3,12 +3,14 @@ import { useEffect, useRef, useState } from 'react'
 import { createRoot } from 'react-dom/client'
 import * as Tone from 'tone'
 import { useOscilloscope, usePlayer, useSpectrogram, useVuMeter, useWaveform } from '@nafr/echo-ui'
+import { useEnvelope } from '../../../packages/hooks/useEnvelope'
 
 type DisposableToneNode = { disposed: boolean }
 
 declare global {
   interface Window {
     __echoActiveAnimationFrames: () => number
+    __echoDisposedMeterCount: () => number
     __echoReleasedNodes: DisposableToneNode[]
     __echoToneHarness: {
       analysis: () => {
@@ -32,6 +34,16 @@ declare global {
         toneVersion: string
       }
       release: () => void
+      scheduling: () => Promise<{
+        afterRelease: number
+        beforeAttack: number
+        contextState: string
+        lfoActiveVariance: number
+        lfoAfterVariance: number
+        lfoBeforeVariance: number
+        peak: number
+        sustain: number
+      }>
       seekPlayer: (time: number) => void
       setWaveform: (channels: number, amplitude: number) => void
       stopPlayer: () => void
@@ -39,6 +51,14 @@ declare global {
     }
   }
 }
+
+let disposedMeterCount = 0
+const disposeMeter = Tone.Meter.prototype.dispose
+Tone.Meter.prototype.dispose = function disposeTrackedMeter(this: Tone.Meter) {
+  if (!this.disposed) disposedMeterCount += 1
+  return disposeMeter.call(this)
+}
+window.__echoDisposedMeterCount = () => disposedMeterCount
 
 const makeBuffer = (duration: number, amplitude: number, channels = 1) => {
   const context = Tone.getContext().rawContext
@@ -56,6 +76,9 @@ const Harness = ({ release }: { release: () => void }) => {
   const spectrogram = useSpectrogram({ fftSize: 128 })
   const meter = useVuMeter({ value: -60 })
   const stereoMeter = useVuMeter({ value: [-60, -60] })
+  const envelope = useEnvelope({
+    data: { attack: 0.02, decay: 0.02, delay: 0.1, hold: 0.04, release: 0.02, sustain: 0.5 },
+  })
   const [waveformBuffer, setWaveformBuffer] = useState<AudioBuffer | null>(null)
   const waveform = useWaveform({ audioBuffer: waveformBuffer, channel: 2, samples: 16 })
   const analysisSource = useRef<Tone.Oscillator | null>(null)
@@ -133,8 +156,46 @@ const Harness = ({ release }: { release: () => void }) => {
           spectrogram.analyser.current,
           meter.meter.current,
           stereoMeter.meter.current,
+          analysisSource.current,
+          envelope.envelope.current,
         ].filter((node): node is DisposableToneNode => node !== null)
         release()
+      },
+      scheduling: async () => {
+        await Tone.start()
+        envelope.init()
+        const envelopeNode = envelope.envelope.current!
+        const scheduledAt = Tone.getContext().immediate() + 0.05
+        envelopeNode.immediate = () => scheduledAt
+        envelope.setHold(0.05)
+        await new Promise<void>((resolveFrame) => {
+          requestAnimationFrame(() => requestAnimationFrame(() => resolveFrame()))
+        })
+        const values = {
+          afterRelease: envelopeNode.getValueAtTime(scheduledAt + 0.23),
+          beforeAttack: envelopeNode.getValueAtTime(scheduledAt + 0.09),
+          peak: envelopeNode.getValueAtTime(scheduledAt + 0.12),
+          sustain: envelopeNode.getValueAtTime(scheduledAt + 0.16),
+        }
+        const renderedLfo = await Tone.Offline(() => {
+          new Tone.LFO({ frequency: 12, min: -1, max: 1 }).start(0.05).stop(0.15).toDestination()
+        }, 0.2)
+        const samples = renderedLfo.getChannelData(0)
+        const variance = (start: number, end: number) => {
+          const segment = samples.slice(
+            Math.floor(start * renderedLfo.sampleRate),
+            Math.floor(end * renderedLfo.sampleRate),
+          )
+          const mean = segment.reduce((sum, value) => sum + value, 0) / segment.length
+          return segment.reduce((sum, value) => sum + (value - mean) ** 2, 0) / segment.length
+        }
+        return {
+          ...values,
+          contextState: Tone.getContext().state,
+          lfoActiveVariance: variance(0.07, 0.13),
+          lfoAfterVariance: variance(0.17, 0.19),
+          lfoBeforeVariance: variance(0.01, 0.03),
+        }
       },
       seekPlayer: player.setPickTime,
       setWaveform: (channels, amplitude) => setWaveformBuffer(makeBuffer(0.1, amplitude, channels)),

--- a/tests/fixtures/tone-browser/main.tsx
+++ b/tests/fixtures/tone-browser/main.tsx
@@ -1,0 +1,154 @@
+/* eslint-disable react-refresh/only-export-components */
+import { useEffect, useRef, useState } from 'react'
+import { createRoot } from 'react-dom/client'
+import * as Tone from 'tone'
+import { useOscilloscope, usePlayer, useSpectrogram, useVuMeter, useWaveform } from '@nafr/echo-ui'
+
+type DisposableToneNode = { disposed: boolean }
+
+declare global {
+  interface Window {
+    __echoActiveAnimationFrames: () => number
+    __echoReleasedNodes: DisposableToneNode[]
+    __echoToneHarness: {
+      analysis: () => {
+        contextState: string
+        meter: number | number[]
+        oscilloscopeSamples: number
+        spectrogramSamples: number
+        stereoMeter: number | number[]
+      }
+      initAnalysis: () => Promise<void>
+      initPlayer: (duration: number, amplitude: number) => void
+      pausePlayer: () => void
+      playPlayer: () => Promise<void>
+      player: () => {
+        disposedReplacedPlayers: boolean
+        instanceOfConsumerTone: boolean
+        isFinish: boolean
+        isPlaying: boolean
+        percentage: number
+        time: number
+        toneVersion: string
+      }
+      release: () => void
+      seekPlayer: (time: number) => void
+      setWaveform: (channels: number, amplitude: number) => void
+      stopPlayer: () => void
+      waveform: () => number[][]
+    }
+  }
+}
+
+const makeBuffer = (duration: number, amplitude: number, channels = 1) => {
+  const context = Tone.getContext().rawContext
+  const frameCount = Math.max(32, Math.floor(context.sampleRate * duration))
+  const buffer = context.createBuffer(channels, frameCount, context.sampleRate)
+  for (let channel = 0; channel < channels; channel += 1) {
+    buffer.getChannelData(channel).fill(amplitude * (channel + 1))
+  }
+  return buffer
+}
+
+const Harness = ({ release }: { release: () => void }) => {
+  const player = usePlayer()
+  const oscilloscope = useOscilloscope({ fftSize: 128 })
+  const spectrogram = useSpectrogram({ fftSize: 128 })
+  const meter = useVuMeter({ value: -60 })
+  const stereoMeter = useVuMeter({ value: [-60, -60] })
+  const [waveformBuffer, setWaveformBuffer] = useState<AudioBuffer | null>(null)
+  const waveform = useWaveform({ audioBuffer: waveformBuffer, channel: 2, samples: 16 })
+  const analysisSource = useRef<Tone.Oscillator | null>(null)
+  const replacedPlayers = useRef<Tone.Player[]>([])
+
+  useEffect(
+    () => () => {
+      try {
+        analysisSource.current?.stop()
+      } catch {
+        // The source may already be stopped during cleanup.
+      }
+      analysisSource.current?.dispose()
+      analysisSource.current = null
+    },
+    [],
+  )
+
+  useEffect(() => {
+    window.__echoToneHarness = {
+      analysis: () => ({
+        contextState: Tone.getContext().state,
+        meter: meter.value,
+        oscilloscopeSamples: oscilloscope.data.length,
+        spectrogramSamples: spectrogram.data.length,
+        stereoMeter: stereoMeter.value,
+      }),
+      initAnalysis: async () => {
+        await Tone.start()
+        oscilloscope.init()
+        spectrogram.init()
+        meter.init()
+        stereoMeter.init()
+        try {
+          analysisSource.current?.stop()
+        } catch {
+          // A prior source may already be stopped.
+        }
+        analysisSource.current?.dispose()
+        const source = new Tone.Oscillator({ frequency: 220, volume: -12 }).toDestination()
+        source.connect(oscilloscope.analyser.current!)
+        source.connect(spectrogram.analyser.current!)
+        source.connect(meter.meter.current!)
+        source.connect(stereoMeter.meter.current!)
+        source.start()
+        analysisSource.current = source
+        oscilloscope.observer()
+        spectrogram.observe()
+        meter.observe()
+        stereoMeter.observe()
+      },
+      initPlayer: (duration, amplitude) => {
+        if (player.player.current) replacedPlayers.current.push(player.player.current)
+        player.init(makeBuffer(duration, amplitude))
+      },
+      pausePlayer: player.pause,
+      playPlayer: async () => {
+        await Tone.start()
+        player.play()
+        player.observe()
+      },
+      player: () => ({
+        disposedReplacedPlayers: replacedPlayers.current.every((node) => node.disposed),
+        instanceOfConsumerTone: player.player.current instanceof Tone.Player,
+        isFinish: player.isFinish,
+        isPlaying: player.isPlaying,
+        percentage: player.percentage,
+        time: player.time,
+        toneVersion: Tone.version,
+      }),
+      release: () => {
+        window.__echoReleasedNodes = [
+          player.player.current,
+          oscilloscope.analyser.current,
+          spectrogram.analyser.current,
+          meter.meter.current,
+          stereoMeter.meter.current,
+        ].filter((node): node is DisposableToneNode => node !== null)
+        release()
+      },
+      seekPlayer: player.setPickTime,
+      setWaveform: (channels, amplitude) => setWaveformBuffer(makeBuffer(0.1, amplitude, channels)),
+      stopPlayer: player.stop,
+      waveform: () => waveform.data,
+    }
+  })
+
+  return <output data-tone-harness="ready">{Tone.version}</output>
+}
+
+const App = () => {
+  const [mounted, setMounted] = useState(true)
+  return mounted ? <Harness release={() => setMounted(false)} /> : <output>released</output>
+}
+
+createRoot(document.getElementById('root')!).render(<App />)

--- a/tests/package-entry.test.ts
+++ b/tests/package-entry.test.ts
@@ -219,4 +219,24 @@ describe('published package', () => {
       expect(bundle.includes('react-jsx-runtime.development.js')).toBe(false)
     }
   })
+
+  it('publishes Tone 15 types while using the consumer Tone runtime', async () => {
+    const [manifest, exampleManifest, esmBundle, umdBundle] = await Promise.all([
+      readFile(resolve(packageRoot, 'package.json'), 'utf8').then(
+        (source) => JSON.parse(source) as PackageManifest,
+      ),
+      readFile(resolve(packageRoot, 'example/package.json'), 'utf8').then(
+        (source) => JSON.parse(source) as PackageManifest,
+      ),
+      readFile(resolve(packageRoot, 'dist/echo-ui.js'), 'utf8'),
+      readFile(resolve(packageRoot, 'dist/echo-ui.umd.cjs'), 'utf8'),
+    ])
+
+    expect(manifest.dependencies.tone).toBe('^15.1.22')
+    expect(exampleManifest.dependencies.tone).toBe('^15.1.22')
+    expect(esmBundle).toMatch(/from ["']tone["']/)
+    expect(umdBundle).toMatch(/require\(["']tone["']\)/)
+    expect(esmBundle).not.toContain('standardized-audio-context')
+    expect(umdBundle).not.toContain('standardized-audio-context')
+  })
 })

--- a/tests/useEnvelope.test.tsx
+++ b/tests/useEnvelope.test.tsx
@@ -1,0 +1,49 @@
+import { act, cleanup, renderHook, waitFor } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { useEnvelope } from '../packages/hooks/useEnvelope'
+
+const tone = vi.hoisted(() => ({ AmplitudeEnvelope: vi.fn() }))
+
+vi.mock('tone', () => tone)
+
+afterEach(() => {
+  cleanup()
+  vi.clearAllMocks()
+})
+
+describe('useEnvelope', () => {
+  it('reschedules valid AHDSR times and disposes the Tone envelope', async () => {
+    const envelopeNode = {
+      attack: 0,
+      cancel: vi.fn(),
+      decay: 0,
+      dispose: vi.fn(),
+      immediate: vi.fn(() => 4),
+      release: 0,
+      sustain: 0,
+      triggerAttack: vi.fn(),
+      triggerRelease: vi.fn(),
+    }
+    tone.AmplitudeEnvelope.mockImplementationOnce(function AmplitudeEnvelope() {
+      return envelopeNode
+    })
+    const { result, unmount } = renderHook(() =>
+      useEnvelope({
+        data: { attack: 0.6, decay: 0.2, delay: 0.1, hold: 0.5, release: 0.2, sustain: 0.8 },
+      }),
+    )
+
+    act(() => {
+      result.current.init()
+      result.current.setHold(0.4)
+    })
+
+    await waitFor(() => expect(envelopeNode.triggerRelease).toHaveBeenCalled())
+    expect(envelopeNode.cancel).toHaveBeenCalledWith(4)
+    expect(envelopeNode.triggerAttack).toHaveBeenCalledWith(4.1)
+    expect(envelopeNode.triggerRelease).toHaveBeenCalledWith(5.3)
+
+    unmount()
+    expect(envelopeNode.dispose).toHaveBeenCalledOnce()
+  })
+})

--- a/tests/useFetchAudio.test.tsx
+++ b/tests/useFetchAudio.test.tsx
@@ -11,6 +11,7 @@ describe('useFetchAudio', () => {
   it('exposes decoded audio after a successful fetch', async () => {
     const decodedAudio = {} as AudioBuffer
     const decodeAudioData = vi.fn().mockResolvedValue(decodedAudio)
+    const close = vi.fn().mockResolvedValue(undefined)
     const arrayBuffer = new ArrayBuffer(8)
     const response = {
       ok: true,
@@ -21,7 +22,7 @@ describe('useFetchAudio', () => {
     vi.stubGlobal(
       'AudioContext',
       vi.fn(function AudioContext() {
-        return { decodeAudioData }
+        return { close, decodeAudioData }
       }),
     )
 
@@ -39,5 +40,6 @@ describe('useFetchAudio', () => {
         audioBuffer: decodedAudio,
       })
     })
+    expect(close).toHaveBeenCalledOnce()
   })
 })

--- a/tests/useOscilloscope.test.tsx
+++ b/tests/useOscilloscope.test.tsx
@@ -1,22 +1,12 @@
 import { act, cleanup, renderHook } from '@testing-library/react'
-import { StrictMode, type PropsWithChildren } from 'react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { useSpectrogram } from '../packages/hooks/useSpectrogram'
+import { useOscilloscope } from '../packages/hooks/useOscilloscope'
 
 const tone = vi.hoisted(() => ({ Analyser: vi.fn() }))
 
 vi.mock('tone', () => ({ Analyser: tone.Analyser }))
 
-const StrictModeWrapper = ({ children }: PropsWithChildren) => <StrictMode>{children}</StrictMode>
-
 beforeEach(() => {
-  tone.Analyser.mockImplementation(function Analyser() {
-    return {
-      dispose: vi.fn(),
-      getValue: vi.fn(() => new Float32Array()),
-      size: 1024,
-    }
-  })
   vi.stubGlobal(
     'requestAnimationFrame',
     vi.fn(() => 42),
@@ -30,29 +20,27 @@ afterEach(() => {
   vi.unstubAllGlobals()
 })
 
-describe('useSpectrogram', () => {
+describe('useOscilloscope', () => {
   it('releases replaced analysers and cancels each observation loop once', () => {
     const firstAnalyser = {
       dispose: vi.fn(),
       getValue: vi.fn(() => new Float32Array()),
-      size: 1024,
     }
     const secondAnalyser = {
       dispose: vi.fn(),
       getValue: vi.fn(() => new Float32Array()),
-      size: 1024,
     }
     tone.Analyser.mockImplementationOnce(function Analyser() {
       return firstAnalyser
     }).mockImplementationOnce(function Analyser() {
       return secondAnalyser
     })
-    const { result, unmount } = renderHook(() => useSpectrogram())
+    const { result, unmount } = renderHook(() => useOscilloscope())
 
     act(() => {
       result.current.init()
       result.current.init()
-      result.current.observe()
+      result.current.observer()
       result.current.cancelObserve()
       result.current.cancelObserve()
     })
@@ -61,28 +49,5 @@ describe('useSpectrogram', () => {
     expect(cancelAnimationFrame).toHaveBeenCalledOnce()
     unmount()
     expect(secondAnalyser.dispose).toHaveBeenCalledOnce()
-  })
-
-  it('notifies callers when the analyser is ready', () => {
-    const onReady = vi.fn()
-    const { result } = renderHook(() => useSpectrogram({ onReady }))
-
-    act(() => result.current.init())
-
-    expect(onReady).toHaveBeenCalledOnce()
-  })
-
-  it('notifies callers when analyser initialization fails', () => {
-    const onError = vi.fn()
-    tone.Analyser.mockImplementationOnce(function Analyser() {
-      throw new Error('invalid fft size')
-    })
-    const { result } = renderHook(() => useSpectrogram({ onError }), {
-      wrapper: StrictModeWrapper,
-    })
-
-    act(() => result.current.init())
-
-    expect(onError).toHaveBeenCalledOnce()
   })
 })

--- a/tests/usePlayer.test.tsx
+++ b/tests/usePlayer.test.tsx
@@ -12,6 +12,8 @@ let playerNode: {
   immediate: ReturnType<typeof vi.fn>
   loop: boolean
   mute: boolean
+  onstop: () => void
+  restart: ReturnType<typeof vi.fn>
   start: ReturnType<typeof vi.fn>
   state: string
   stop: ReturnType<typeof vi.fn>
@@ -19,23 +21,30 @@ let playerNode: {
   volume: { value: number }
 }
 
+const createPlayerNode = () => ({
+  chain: vi.fn(),
+  dispose: vi.fn(),
+  immediate: vi.fn(() => 1),
+  loop: false,
+  mute: false,
+  onstop: vi.fn(),
+  restart: vi.fn(),
+  start: vi.fn(),
+  state: 'stopped',
+  stop: vi.fn(),
+  toDestination: vi.fn(),
+  volume: { value: 0 },
+})
+
 beforeEach(() => {
-  playerNode = {
-    chain: vi.fn(),
-    dispose: vi.fn(),
-    immediate: vi.fn(() => 1),
-    loop: false,
-    mute: false,
-    start: vi.fn(),
-    state: 'stopped',
-    stop: vi.fn(),
-    toDestination: vi.fn(),
-    volume: { value: 0 },
-  }
+  playerNode = createPlayerNode()
   tone.Player.mockImplementation(function Player() {
     return playerNode
   })
-  vi.stubGlobal('requestAnimationFrame', vi.fn(() => 42))
+  vi.stubGlobal(
+    'requestAnimationFrame',
+    vi.fn(() => 42),
+  )
   vi.stubGlobal('cancelAnimationFrame', vi.fn())
 })
 
@@ -46,6 +55,64 @@ afterEach(() => {
 })
 
 describe('usePlayer', () => {
+  it('reports natural completion without treating an explicit stop as a finish', () => {
+    const onFinish = vi.fn()
+    let immediateTime = 5
+    const node = createPlayerNode()
+    node.immediate.mockImplementation(() => immediateTime)
+    tone.Player.mockImplementationOnce(function Player() {
+      return node
+    })
+    const { result } = renderHook(() => usePlayer({ onFinish }))
+
+    act(() => {
+      result.current.init({ duration: 2 } as AudioBuffer)
+      result.current.play()
+      result.current.stop()
+      node.onstop()
+    })
+    expect(onFinish).not.toHaveBeenCalled()
+
+    act(() => {
+      result.current.play()
+      immediateTime = 7
+      node.onstop()
+    })
+
+    expect(onFinish).toHaveBeenCalledOnce()
+    expect(result.current.isFinish).toBe(true)
+    expect(result.current.isPlaying).toBe(false)
+    expect(result.current.time).toBe(2)
+    expect(result.current.percentage).toBe(100)
+  })
+
+  it('releases the previous player and resets progress when the source changes', () => {
+    const firstPlayer = createPlayerNode()
+    const secondPlayer = createPlayerNode()
+    tone.Player.mockImplementationOnce(function Player() {
+      return firstPlayer
+    }).mockImplementationOnce(function Player() {
+      return secondPlayer
+    })
+    const { result } = renderHook(() => usePlayer())
+
+    act(() => {
+      result.current.init({ duration: 10 } as AudioBuffer)
+      result.current.setPickTime(4)
+      result.current.getTime()
+    })
+    expect(result.current.time).toBe(4)
+
+    act(() => result.current.init({ duration: 2 } as AudioBuffer))
+
+    expect(firstPlayer.stop).toHaveBeenCalledOnce()
+    expect(firstPlayer.dispose).toHaveBeenCalledOnce()
+    expect(result.current.player.current).toBe(secondPlayer)
+    expect(result.current.audioDuration.current).toBe(2)
+    expect(result.current.time).toBe(0)
+    expect(result.current.percentage).toBe(0)
+  })
+
   it('can cancel progress observation after playback reports an error', async () => {
     const { result } = renderHook(() => usePlayer())
     playerNode.start.mockImplementationOnce(() => {

--- a/tests/useVuMeter.test.tsx
+++ b/tests/useVuMeter.test.tsx
@@ -2,18 +2,13 @@ import { act, cleanup, renderHook } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { useVuMeter } from '../packages/hooks/useVuMeter'
 
-const tone = vi.hoisted(() => ({ Meter: vi.fn(), Split: vi.fn() }))
+const tone = vi.hoisted(() => ({ Meter: vi.fn() }))
 
 vi.mock('tone', () => tone)
 
 const createMeter = () => ({
   dispose: vi.fn(),
   getValue: vi.fn(() => -12),
-})
-
-const createSplit = () => ({
-  connect: vi.fn(),
-  dispose: vi.fn(),
 })
 
 beforeEach(() => {
@@ -31,19 +26,11 @@ afterEach(() => {
 })
 
 describe('useVuMeter', () => {
-  it('normalizes Tone 15 meter arrays and releases every stereo node', () => {
-    const leftMeter = createMeter()
-    const rightMeter = createMeter()
-    leftMeter.getValue.mockReturnValue(new Float32Array([-11]) as never)
-    rightMeter.getValue.mockReturnValue(new Float32Array([-13]) as never)
-    const split = createSplit()
+  it('uses the Tone 15 multichannel meter API and releases the stereo node', () => {
+    const stereoMeter = createMeter()
+    stereoMeter.getValue.mockReturnValue([-11, -13])
     tone.Meter.mockImplementationOnce(function Meter() {
-      return leftMeter
-    }).mockImplementationOnce(function Meter() {
-      return rightMeter
-    })
-    tone.Split.mockImplementationOnce(function Split() {
-      return split
+      return stereoMeter
     })
     const { result, unmount } = renderHook(() => useVuMeter({ value: [-60, -60] }))
 
@@ -51,6 +38,7 @@ describe('useVuMeter', () => {
       result.current.init()
       result.current.getValue()
     })
+    expect(tone.Meter).toHaveBeenCalledWith({ channelCount: 2 })
     expect(result.current.value).toEqual([-11, -13])
 
     act(() => {
@@ -61,8 +49,7 @@ describe('useVuMeter', () => {
 
     expect(cancelAnimationFrame).toHaveBeenCalledOnce()
     unmount()
-    expect(split.dispose).toHaveBeenCalledOnce()
-    expect(leftMeter.dispose).toHaveBeenCalledOnce()
-    expect(rightMeter.dispose).toHaveBeenCalledOnce()
+    expect(result.current.meter.current).toBe(null)
+    expect(stereoMeter.dispose).toHaveBeenCalledOnce()
   })
 })

--- a/tests/useVuMeter.test.tsx
+++ b/tests/useVuMeter.test.tsx
@@ -1,0 +1,68 @@
+import { act, cleanup, renderHook } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { useVuMeter } from '../packages/hooks/useVuMeter'
+
+const tone = vi.hoisted(() => ({ Meter: vi.fn(), Split: vi.fn() }))
+
+vi.mock('tone', () => tone)
+
+const createMeter = () => ({
+  dispose: vi.fn(),
+  getValue: vi.fn(() => -12),
+})
+
+const createSplit = () => ({
+  connect: vi.fn(),
+  dispose: vi.fn(),
+})
+
+beforeEach(() => {
+  vi.stubGlobal(
+    'requestAnimationFrame',
+    vi.fn(() => 42),
+  )
+  vi.stubGlobal('cancelAnimationFrame', vi.fn())
+})
+
+afterEach(() => {
+  cleanup()
+  vi.clearAllMocks()
+  vi.unstubAllGlobals()
+})
+
+describe('useVuMeter', () => {
+  it('normalizes Tone 15 meter arrays and releases every stereo node', () => {
+    const leftMeter = createMeter()
+    const rightMeter = createMeter()
+    leftMeter.getValue.mockReturnValue(new Float32Array([-11]) as never)
+    rightMeter.getValue.mockReturnValue(new Float32Array([-13]) as never)
+    const split = createSplit()
+    tone.Meter.mockImplementationOnce(function Meter() {
+      return leftMeter
+    }).mockImplementationOnce(function Meter() {
+      return rightMeter
+    })
+    tone.Split.mockImplementationOnce(function Split() {
+      return split
+    })
+    const { result, unmount } = renderHook(() => useVuMeter({ value: [-60, -60] }))
+
+    act(() => {
+      result.current.init()
+      result.current.getValue()
+    })
+    expect(result.current.value).toEqual([-11, -13])
+
+    act(() => {
+      result.current.observe()
+      result.current.cancelObserve()
+      result.current.cancelObserve()
+    })
+
+    expect(cancelAnimationFrame).toHaveBeenCalledOnce()
+    unmount()
+    expect(split.dispose).toHaveBeenCalledOnce()
+    expect(leftMeter.dispose).toHaveBeenCalledOnce()
+    expect(rightMeter.dispose).toHaveBeenCalledOnce()
+  })
+})

--- a/tests/useWaveform.test.tsx
+++ b/tests/useWaveform.test.tsx
@@ -1,0 +1,38 @@
+import { cleanup, renderHook, waitFor } from '@testing-library/react'
+import { afterEach, describe, expect, it } from 'vitest'
+import { useWaveform } from '../packages/hooks/useWaveform'
+
+const createAudioBuffer = (channels: number[][], duration = 1) =>
+  ({
+    duration,
+    numberOfChannels: channels.length,
+    getChannelData: (channel: number) => Float32Array.from(channels[channel]),
+  }) as AudioBuffer
+
+afterEach(cleanup)
+
+describe('useWaveform', () => {
+  it('recomputes finite samples for source changes and available channels', async () => {
+    const monoBuffer = createAudioBuffer([[0.25, -0.25, 0.25, -0.25]])
+    const stereoBuffer = createAudioBuffer([
+      [0.75, -0.75, 0.75, -0.75],
+      [0.5, -0.5, 0.5, -0.5],
+    ])
+    const { result, rerender } = renderHook(
+      ({ audioBuffer }) => useWaveform({ audioBuffer, channel: 2, samples: 8 }),
+      { initialProps: { audioBuffer: monoBuffer } },
+    )
+
+    await waitFor(() => expect(result.current.data).toHaveLength(1))
+    expect(result.current.data[0]).toHaveLength(8)
+    expect(result.current.data.flat().every((value) => Number.isFinite(value))).toBe(true)
+    expect(result.current.error).toBe(false)
+
+    rerender({ audioBuffer: stereoBuffer })
+
+    await waitFor(() => expect(result.current.data).toHaveLength(2))
+    expect(result.current.data[0][0]).toBeCloseTo(0.75)
+    expect(result.current.data[1][0]).toBeCloseTo(0.5)
+    expect(result.current.audioDuration.current).toBe(1)
+  })
+})

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -33,7 +33,7 @@ export default defineConfig(({ command }) => ({
       cssFileName: 'echo-ui',
     },
     rolldownOptions: {
-      external: ['react', 'react-dom'],
+      external: ['react', 'react-dom', 'tone'],
       transform: {
         inject: {
           React: 'react',
@@ -43,6 +43,7 @@ export default defineConfig(({ command }) => ({
         globals: {
           react: 'React',
           'react-dom': 'ReactDOM',
+          tone: 'Tone',
         },
       },
     },


### PR DESCRIPTION
## Summary

- migrate Echo UI audio hooks, package consumers, and examples to Tone.js 15.1.22
- update player, analyser, multichannel meter, envelope, LFO, and cleanup behavior for current APIs
- document the Tone dependency and externalization contract and add real-browser lifecycle coverage

## Verification

- pnpm verify
- pnpm lint
- standards review: no blockers
- issue-spec review: no remaining gaps

Closes #87