### PR TITLE
chore: verify modernized package and documentation release

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Echo UI is a high-performance and out-of-the-box web audio API component library
   <img src="https://img.shields.io/badge/ROADMAP-ffbe3b?style=flat" />
 </a>
 
-<a href="./LICENSE.md"> 
+<a href="./LICENSE">
   <img src="https://img.shields.io/badge/License-MIT-ffbe3b?style=flat&labelColor=ffbe3b" />
 </a>
 
@@ -56,15 +56,17 @@ From a fresh checkout:
 nvm use
 corepack enable
 pnpm install --frozen-lockfile
-pnpm verify
+pnpm verify:frozen
 ```
 
-`pnpm verify` runs the library, example, and documentation type checks, builds, unit tests, and static-site browser checks. These checks can also be run independently:
+`pnpm verify:frozen` installs the exact lockfile and runs the complete release gate. `pnpm verify` runs the same lint, type, package-artifact, consumer, library, example, documentation, and browser checks without reinstalling. The supported matrix and migration notes are recorded in [RELEASE_NOTES.md](./RELEASE_NOTES.md). These checks can also be run independently:
 
 ```bash
 pnpm typecheck
 pnpm build
 pnpm test
+pnpm test:package
+pnpm verify:release
 pnpm typecheck:example
 pnpm build:example
 pnpm typecheck:docs
@@ -78,4 +80,4 @@ The production documentation is built from the `docs` workspace and exported to 
 
 ## License
 
-[MIT](./LICENSE.md) © 2023-Present [leyoonafr](https://github.com/codeacme17)
+[MIT](./LICENSE) © 2023-Present [leyoonafr](https://github.com/codeacme17)

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,0 +1,51 @@
+# Echo UI 1.1.0 release notes
+
+Echo UI 1.1.0 is the coherent release of the package, build, documentation, React, Tailwind, and audio modernization work completed in issues #76–#87.
+
+## Supported versions
+
+| Contract                  | Verified version or range                  |
+| ------------------------- | ------------------------------------------ |
+| Runtime                   | Node.js 24 and pnpm 10.22.0                |
+| React peers               | React and React DOM `^18.2.0 \|\| ^19.0.0` |
+| Installed React consumers | React 18.3.1 and React 19.2.8              |
+| Styling                   | Tailwind CSS 3.4.19 and Tailwind CSS 4.3.3 |
+| Documentation             | Next.js 16.2.10 and Nextra 4.6.0           |
+| Audio                     | Tone.js 15.1.22                            |
+
+## Consumer migration
+
+### React
+
+Applications may remain on React 18 or move to React 19. React and React DOM must use matching versions. They remain peer dependencies and are externalized from Echo UI's ESM and UMD bundles, so consumers provide one React runtime. React 19 callback-ref cleanup is supported without dropping React 18 callback refs.
+
+The production library build intentionally uses the classic JSX runtime with Vite `React` injection while keeping React external. This documented compatibility bridge lets the same compiled artifact run with React 18 and React 19; the artifact audit also verifies that no `react/jsx-runtime` implementation is embedded.
+
+### Tailwind CSS
+
+Tailwind CSS 4 is the recommended path. Import `tailwindcss` and `@nafr/echo-ui/theme.css`, add `@source "../node_modules/@nafr/echo-ui/dist"`, and enable `@tailwindcss/vite`.
+
+Tailwind CSS 3 remains supported. Import the published theme before the three Tailwind layers, scan `node_modules/@nafr/echo-ui/dist/**/*.{js,cjs}`, and import `theme` from `@nafr/echo-ui/tailwind-theme`. When moving from Tailwind 3 to 4, review the changed shadow, outline, border, radius, palette, and transition semantics described in the installation guide.
+
+### Documentation
+
+The documentation application now uses Nextra instead of IslandJS. IslandJS and NextUI packages, build commands, and generated output are no longer part of the repository. The only documentation compatibility bridge is the generated set of legacy documentation redirects from the old component and Hook URLs to their localized Nextra routes.
+
+### Tone.js
+
+Tone.js 15.1.22 replaces Tone 14 throughout the package and examples. Tone is a direct dependency because public Hook declarations expose Tone types, but it is externalized from the ESM and UMD bundles so an application resolves one Tone runtime. Consumers importing Tone directly should use `^15.1.22`. Player restart/stop behavior, analyser return shapes, multichannel meters, envelope/LFO scheduling, and node disposal have all been migrated and browser-tested.
+
+## Published artifact
+
+The package exports the ESM and UMD library entries, declarations, `style.css`, `theme.css`, and the Tailwind 3 theme module. The legacy npm metadata fields `main`/`module`/`types`/`style` mirror those explicit exports. CSS is the only declared side effect. React, React DOM, and Tone stay outside the bundles; all other runtime implementation dependencies are packaged through the bundle.
+
+## Release verification
+
+From a clean checkout on the supported runtime:
+
+```bash
+corepack enable
+pnpm verify:frozen
+```
+
+The frozen gate installs the lockfile and verifies lint, type declarations, unit tests, packed React and Tailwind consumers, the published artifact contract, production library/example/Nextra builds, internal documentation links, and representative browser audio lifecycles.

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -5,13 +5,7 @@ import globals from 'globals'
 import tseslint from 'typescript-eslint'
 
 export default defineConfig([
-  globalIgnores([
-    'dist/**',
-    'example/dist/**',
-    'docs/.island/dist/**',
-    'docs/.next/**',
-    'docs/out/**',
-  ]),
+  globalIgnores(['dist/**', 'example/dist/**', 'docs/.next/**', 'docs/out/**']),
   {
     files: ['**/*.{ts,tsx}'],
     extends: [tseslint.configs.recommended],

--- a/package.json
+++ b/package.json
@@ -47,13 +47,15 @@
     "**/*.css"
   ],
   "files": [
-    "dist"
+    "dist",
+    "RELEASE_NOTES.md"
   ],
   "scripts": {
     "build": "vite build && tsc",
     "typecheck": "tsc --noEmit",
     "lint": "eslint . --max-warnings 0",
     "test": "pnpm build && vitest run && pnpm test:react-compat && pnpm test:tone-browser && node scripts/smoke-tailwind-consumers.mjs",
+    "test:package": "pnpm build && node scripts/verify-package-artifact.mjs",
     "test:react-compat": "node scripts/smoke-react-consumers.mjs",
     "test:tone-browser": "node scripts/smoke-tone-hooks.mjs",
     "test:tone-examples": "node scripts/smoke-tone-examples.mjs",
@@ -69,7 +71,9 @@
     "preview:docs": "node scripts/serve-docs.mjs",
     "typecheck:docs": "pnpm --filter @nafr/echo-ui-docs typecheck",
     "test:docs": "pnpm test:tailwind-docs && node scripts/verify-nextra-output.mjs && node scripts/smoke-nextra-routes.mjs && node scripts/verify-docs-ui.mjs",
-    "verify": "pnpm typecheck && pnpm typecheck:example && pnpm typecheck:docs && pnpm test && pnpm build:example && pnpm test:tone-examples && pnpm build:docs && pnpm test:docs",
+    "verify:contract": "node scripts/verify-release-contract.mjs",
+    "verify:release": "pnpm verify:contract && pnpm test:package",
+    "verify": "pnpm verify:contract && pnpm lint && pnpm typecheck && pnpm typecheck:example && pnpm typecheck:docs && pnpm test && node scripts/verify-package-artifact.mjs && pnpm build:example && pnpm test:tone-examples && pnpm build:docs && pnpm test:docs",
     "verify:frozen": "pnpm install --frozen-lockfile && pnpm verify"
   },
   "devDependencies": {

--- a/scripts/release-matrix.mjs
+++ b/scripts/release-matrix.mjs
@@ -1,0 +1,20 @@
+export const releaseMatrix = Object.freeze({
+  echoUi: '1.1.0',
+  next: '16.2.10',
+  nextra: '4.6.0',
+  nodeMajor: 24,
+  pnpm: '10.22.0',
+  react: Object.freeze({
+    peerRange: '^18.2.0 || ^19.0.0',
+    tested: Object.freeze({ react18: '18.3.1', react19: '19.2.8' }),
+    workspace: '19.2.8',
+  }),
+  tailwind: Object.freeze({
+    tested: Object.freeze({ tailwind3: '3.4.19', tailwind4: '4.3.3' }),
+    workspace: '4.3.3',
+  }),
+  tone: Object.freeze({
+    range: '^15.1.22',
+    tested: '15.1.22',
+  }),
+})

--- a/scripts/smoke-react-consumers.mjs
+++ b/scripts/smoke-react-consumers.mjs
@@ -1,9 +1,11 @@
 import assert from 'node:assert/strict'
 import { execFileSync } from 'node:child_process'
-import { mkdtemp, mkdir, readFile, rm, writeFile } from 'node:fs/promises'
+import { mkdtemp, mkdir, readFile, realpath, rm, writeFile } from 'node:fs/promises'
+import { createRequire } from 'node:module'
 import { tmpdir } from 'node:os'
 import { join, resolve } from 'node:path'
 import { packLocalPackage } from './pack-local-package.mjs'
+import { releaseMatrix } from './release-matrix.mjs'
 
 const packageRoot = resolve(import.meta.dirname, '..')
 const consumerRoot = await mkdtemp(join(tmpdir(), 'echo-ui-react-consumers-'))
@@ -11,12 +13,12 @@ const consumers = [
   {
     reactDomTypesVersion: '18.3.7',
     reactTypesVersion: '18.3.31',
-    reactVersion: '18.3.1',
+    reactVersion: releaseMatrix.react.tested.react18,
   },
   {
     reactDomTypesVersion: '19.2.3',
     reactTypesVersion: '19.2.17',
-    reactVersion: '19.2.8',
+    reactVersion: releaseMatrix.react.tested.react19,
   },
 ]
 
@@ -37,7 +39,7 @@ try {
             '@nafr/echo-ui': `file:${archivePath}`,
             react: reactVersion,
             'react-dom': reactVersion,
-            tone: '15.1.22',
+            tone: releaseMatrix.tone.tested,
           },
           devDependencies: {
             '@types/react': reactTypesVersion,
@@ -215,8 +217,25 @@ console.log(JSON.stringify({ markup, reactDomVersion, reactVersion, toneVersion 
       readFile(join(installedPackageRoot, 'dist', 'echo-ui.umd.cjs'), 'utf8'),
     ])
     assert.equal(installedManifest.dependencies.tone, '^15.1.22')
+    assert.equal(installedManifest.peerDependencies.react, releaseMatrix.react.peerRange)
+    assert.equal(installedManifest.peerDependencies['react-dom'], releaseMatrix.react.peerRange)
     assert.match(esmBundle, /from ["']tone["']/)
+    assert.match(esmBundle, /from ["']react["']/)
     assert.match(umdBundle, /require\(["']tone["']\)/)
+    assert.match(umdBundle, /require\(["']react["']\)/)
+
+    const consumerRequire = createRequire(join(consumerDirectory, 'package.json'))
+    const packageRequire = createRequire(join(installedPackageRoot, 'package.json'))
+    assert.equal(
+      await realpath(consumerRequire.resolve('react')),
+      await realpath(packageRequire.resolve('react')),
+      `React ${reactVersion} consumer resolved a second React copy`,
+    )
+    assert.equal(
+      await realpath(consumerRequire.resolve('react-dom')),
+      await realpath(packageRequire.resolve('react-dom')),
+      `React ${reactVersion} consumer resolved a second React DOM copy`,
+    )
     execFileSync('pnpm', ['exec', 'tsc'], { cwd: consumerDirectory, stdio: 'pipe' })
     const result = JSON.parse(
       execFileSync(process.execPath, ['render.mjs'], {
@@ -227,8 +246,8 @@ console.log(JSON.stringify({ markup, reactDomVersion, reactVersion, toneVersion 
 
     assert.equal(result.reactVersion, reactVersion)
     assert.equal(result.reactDomVersion, reactVersion)
-    assert.equal(result.toneVersion, '15.1.22')
-    console.log(`React ${reactVersion} consumer installed and rendered Echo UI.`)
+    assert.equal(result.toneVersion, releaseMatrix.tone.tested)
+    console.log(`React ${reactVersion} consumer rendered Echo UI with one React runtime.`)
   }
 } finally {
   await rm(consumerRoot, { force: true, recursive: true })

--- a/scripts/smoke-tailwind-consumers.mjs
+++ b/scripts/smoke-tailwind-consumers.mjs
@@ -6,6 +6,7 @@ import { tmpdir } from 'node:os'
 import { extname, join, resolve } from 'node:path'
 import { launchBrowser } from './launch-browser.mjs'
 import { packLocalPackage } from './pack-local-package.mjs'
+import { releaseMatrix } from './release-matrix.mjs'
 
 const packageRoot = resolve(import.meta.dirname, '..')
 const consumerRoot = await mkdtemp(join(tmpdir(), 'echo-ui-tailwind-consumers-'))
@@ -14,13 +15,13 @@ const servers = []
 const consumers = [
   {
     name: 'tailwind-3',
-    tailwindVersion: '3.4.19',
+    tailwindVersion: releaseMatrix.tailwind.tested.tailwind3,
     devDependencies: {
       '@vitejs/plugin-react': '6.0.3',
       autoprefixer: '10.5.4',
       postcss: '8.5.21',
       'postcss-import': '15.1.0',
-      tailwindcss: '3.4.19',
+      tailwindcss: releaseMatrix.tailwind.tested.tailwind3,
       vite: '8.1.5',
     },
     files: {
@@ -58,11 +59,11 @@ export default defineConfig({ plugins: [react()] })
   },
   {
     name: 'tailwind-4',
-    tailwindVersion: '4.3.3',
+    tailwindVersion: releaseMatrix.tailwind.tested.tailwind4,
     devDependencies: {
-      '@tailwindcss/vite': '4.3.3',
+      '@tailwindcss/vite': releaseMatrix.tailwind.tested.tailwind4,
       '@vitejs/plugin-react': '6.0.3',
-      tailwindcss: '4.3.3',
+      tailwindcss: releaseMatrix.tailwind.tested.tailwind4,
       vite: '8.1.5',
     },
     files: {
@@ -218,8 +219,8 @@ try {
           scripts: { build: 'vite build' },
           dependencies: {
             '@nafr/echo-ui': `file:${archivePath}`,
-            react: '19.2.8',
-            'react-dom': '19.2.8',
+            react: releaseMatrix.react.workspace,
+            'react-dom': releaseMatrix.react.workspace,
           },
           devDependencies: consumer.devDependencies,
         },

--- a/scripts/verify-package-artifact.mjs
+++ b/scripts/verify-package-artifact.mjs
@@ -1,0 +1,137 @@
+import assert from 'node:assert/strict'
+import { execFileSync } from 'node:child_process'
+import { access, mkdtemp, mkdir, readFile, rm, stat } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
+import { packLocalPackage } from './pack-local-package.mjs'
+import { releaseMatrix } from './release-matrix.mjs'
+
+const packageRoot = resolve(import.meta.dirname, '..')
+const auditRoot = await mkdtemp(join(tmpdir(), 'echo-ui-package-audit-'))
+
+const resolveTarget = (artifactRoot, target) => {
+  const normalizedTarget = target.startsWith('./') ? target.slice(2) : target
+  assert.match(normalizedTarget, /^dist\//, `Published target must stay in dist: ${target}`)
+  return resolve(artifactRoot, normalizedTarget)
+}
+
+try {
+  const archivePath = await packLocalPackage(packageRoot, auditRoot)
+  const extractRoot = join(auditRoot, 'extracted')
+  await mkdir(extractRoot)
+  execFileSync('tar', ['-xzf', archivePath, '-C', extractRoot])
+
+  const artifactRoot = join(extractRoot, 'package')
+  const manifest = JSON.parse(await readFile(join(artifactRoot, 'package.json'), 'utf8'))
+  const archiveEntries = execFileSync('tar', ['-tzf', archivePath], { encoding: 'utf8' })
+    .trim()
+    .split('\n')
+
+  assert.equal(manifest.name, '@nafr/echo-ui')
+  assert.equal(manifest.version, releaseMatrix.echoUi)
+  assert.deepEqual(manifest.files, ['dist', 'RELEASE_NOTES.md'])
+  assert.deepEqual(manifest.sideEffects, ['**/*.css'])
+  assert.deepEqual(manifest.peerDependencies, {
+    react: releaseMatrix.react.peerRange,
+    'react-dom': releaseMatrix.react.peerRange,
+  })
+  assert.equal(manifest.dependencies.tone, releaseMatrix.tone.range)
+  assert.deepEqual(
+    Object.keys(manifest.dependencies).filter(
+      (name) => manifest.devDependencies?.[name] || manifest.peerDependencies?.[name],
+    ),
+    [],
+    'Runtime dependencies must not be duplicated in development or peer dependencies',
+  )
+  assert.deepEqual(Object.keys(manifest.dependencies).sort(), [
+    'clsx',
+    'd3',
+    'tailwind-merge',
+    'tailwind-variants',
+    'tone',
+  ])
+
+  const publicTargets = [
+    manifest.main,
+    manifest.module,
+    manifest.types,
+    manifest.style,
+    manifest.exports['.'].types,
+    manifest.exports['.'].import,
+    manifest.exports['.'].require,
+    manifest.exports['./style.css'],
+    manifest.exports['./theme.css'],
+    manifest.exports['./tailwind-theme'].types,
+    manifest.exports['./tailwind-theme'].import,
+  ]
+  await Promise.all(publicTargets.map((target) => access(resolveTarget(artifactRoot, target))))
+  assert.equal(manifest.main, manifest.exports['.'].require.slice(2))
+  assert.equal(manifest.module, manifest.exports['.'].import.slice(2))
+  assert.equal(manifest.types, manifest.exports['.'].types.slice(2))
+  assert.equal(manifest.style, manifest.exports['./style.css'].slice(2))
+
+  const [declarations, esmBundle, libraryCss, readme, releaseNotes, themeCss, umdBundle] =
+    await Promise.all([
+      readFile(resolveTarget(artifactRoot, manifest.types), 'utf8'),
+      readFile(resolveTarget(artifactRoot, manifest.module), 'utf8'),
+      readFile(resolveTarget(artifactRoot, manifest.style), 'utf8'),
+      readFile(join(artifactRoot, 'README.md'), 'utf8'),
+      readFile(join(artifactRoot, 'RELEASE_NOTES.md'), 'utf8'),
+      readFile(resolveTarget(artifactRoot, manifest.exports['./theme.css']), 'utf8'),
+      readFile(resolveTarget(artifactRoot, manifest.main), 'utf8'),
+    ])
+  assert.match(declarations, /export \{ useFetchAudio, useOscilloscope, usePlayer/)
+  assert.match(declarations, /UseVuMeterProps/)
+  assert.match(esmBundle, /from ["']react["']/)
+  assert.match(esmBundle, /from ["']tone["']/)
+  assert.match(umdBundle, /require\(["']react["']\)/)
+  assert.match(umdBundle, /require\(["']tone["']\)/)
+  const esmExternals = [
+    ...new Set(
+      [...esmBundle.matchAll(/\bfrom ["']([^"']+)["']/g)]
+        .map((match) => match[1])
+        .filter((specifier) => !specifier.startsWith('.') && !specifier.startsWith('/')),
+    ),
+  ].sort()
+  const umdExternals = [
+    ...new Set([...umdBundle.matchAll(/\brequire\(["']([^"']+)["']\)/g)].map((match) => match[1])),
+  ].sort()
+  assert.deepEqual(esmExternals, ['react', 'tone'])
+  assert.deepEqual(umdExternals, ['react', 'tone'])
+  assert.doesNotMatch(esmBundle, /node_modules\/react/)
+  assert.doesNotMatch(umdBundle, /node_modules\/react/)
+  assert.match(libraryCss, /\.bg-button/)
+  assert.match(themeCss, /--echo-primary:/)
+  assert.match(readme, /\[MIT\]\(\.\/LICENSE\)/)
+  assert.doesNotMatch(readme, /LICENSE\.md/)
+  assert.match(releaseNotes, /# Echo UI 1\.1\.0 release notes/)
+  assert.ok((await stat(archivePath)).size > 100_000)
+
+  assert.ok(archiveEntries.includes('package/package.json'))
+  assert.ok(archiveEntries.includes('package/README.md'))
+  assert.ok(archiveEntries.includes('package/RELEASE_NOTES.md'))
+  assert.ok(archiveEntries.includes('package/LICENSE'))
+  assert.ok(archiveEntries.includes('package/dist/echo-ui.js'))
+  assert.ok(archiveEntries.includes('package/dist/echo-ui.umd.cjs'))
+  assert.ok(archiveEntries.includes('package/dist/echo-ui.css'))
+  assert.ok(archiveEntries.includes('package/dist/theme.css'))
+  assert.ok(archiveEntries.includes('package/dist/types/packages/main.d.ts'))
+  assert.ok(
+    archiveEntries.every(
+      (entry) =>
+        entry.startsWith('package/dist/') ||
+        [
+          'package/LICENSE',
+          'package/README.md',
+          'package/RELEASE_NOTES.md',
+          'package/package.json',
+        ].includes(entry),
+    ),
+    'The archive contains files outside the documented package surface',
+  )
+  assert.ok(!archiveEntries.some((entry) => /(?:node_modules|docs\/out|\.tsbuildinfo)/.test(entry)))
+
+  console.log(`Packed Echo UI ${releaseMatrix.echoUi} artifact is verified.`)
+} finally {
+  await rm(auditRoot, { force: true, recursive: true })
+}

--- a/scripts/verify-release-contract.mjs
+++ b/scripts/verify-release-contract.mjs
@@ -1,0 +1,148 @@
+import assert from 'node:assert/strict'
+import { execFileSync } from 'node:child_process'
+import { readFile } from 'node:fs/promises'
+import { resolve } from 'node:path'
+import { loadConfigFromFile } from 'vite'
+import { releaseMatrix } from './release-matrix.mjs'
+
+const repositoryRoot = resolve(import.meta.dirname, '..')
+const readJson = (path) => readFile(resolve(repositoryRoot, path), 'utf8').then(JSON.parse)
+
+const [eslintConfig, manifest, docsManifest, exampleManifest, lockfile, notes, nvmrc, viteSource] =
+  await Promise.all([
+    readFile(resolve(repositoryRoot, 'eslint.config.js'), 'utf8'),
+    readJson('package.json'),
+    readJson('docs/package.json'),
+    readJson('example/package.json'),
+    readFile(resolve(repositoryRoot, 'pnpm-lock.yaml'), 'utf8'),
+    readFile(resolve(repositoryRoot, 'RELEASE_NOTES.md'), 'utf8'),
+    readFile(resolve(repositoryRoot, '.nvmrc'), 'utf8').then((value) => value.trim()),
+    readFile(resolve(repositoryRoot, 'vite.config.ts'), 'utf8'),
+  ])
+
+const loadedViteConfig = await loadConfigFromFile(
+  { command: 'build', mode: 'production' },
+  resolve(repositoryRoot, 'vite.config.ts'),
+)
+assert.ok(loadedViteConfig)
+assert.deepEqual(loadedViteConfig.config.build.rolldownOptions.external, [
+  'react',
+  'react-dom',
+  'tone',
+])
+assert.match(viteSource, /jsxRuntime: command === 'build' \? 'classic' : 'automatic'/)
+assert.match(viteSource, /inject:\s*{\s*React: 'react'/)
+
+assert.equal(Number(process.versions.node.split('.')[0]), releaseMatrix.nodeMajor)
+assert.equal(
+  execFileSync('pnpm', ['--version'], { cwd: repositoryRoot, encoding: 'utf8' }).trim(),
+  releaseMatrix.pnpm,
+)
+assert.equal(manifest.version, releaseMatrix.echoUi)
+assert.equal(manifest.packageManager, `pnpm@${releaseMatrix.pnpm}`)
+assert.deepEqual(manifest.engines, { node: '>=24 <25', pnpm: '>=10 <11' })
+assert.equal(nvmrc, String(releaseMatrix.nodeMajor))
+assert.equal(manifest.peerDependencies.react, releaseMatrix.react.peerRange)
+assert.equal(manifest.peerDependencies['react-dom'], releaseMatrix.react.peerRange)
+assert.equal(manifest.dependencies.tone, releaseMatrix.tone.range)
+assert.equal(manifest.devDependencies.react, releaseMatrix.react.workspace)
+assert.equal(manifest.devDependencies['react-dom'], releaseMatrix.react.workspace)
+assert.equal(manifest.devDependencies.tailwindcss, releaseMatrix.tailwind.workspace)
+assert.equal(docsManifest.dependencies.next, releaseMatrix.next)
+assert.equal(docsManifest.dependencies.nextra, releaseMatrix.nextra)
+assert.equal(docsManifest.dependencies['nextra-theme-docs'], releaseMatrix.nextra)
+assert.equal(docsManifest.dependencies.react, releaseMatrix.react.workspace)
+assert.equal(exampleManifest.dependencies.react, releaseMatrix.react.workspace)
+assert.equal(exampleManifest.dependencies.tone, releaseMatrix.tone.range)
+assert.equal(exampleManifest.devDependencies.tailwindcss, releaseMatrix.tailwind.workspace)
+assert.ok(!eslintConfig.includes('docs/.island'), 'ESLint still ignores removed IslandJS output')
+assert.match(manifest.scripts.verify, /pnpm lint/)
+assert.match(manifest.scripts.verify, /verify-package-artifact/)
+assert.equal(manifest.scripts['verify:frozen'], 'pnpm install --frozen-lockfile && pnpm verify')
+
+const deprecatedPackages = ['@nextui-org/react', '@nextui-org/theme', 'islandjs']
+const manifests = [manifest, docsManifest, exampleManifest]
+for (const packageName of deprecatedPackages) {
+  for (const workspaceManifest of manifests) {
+    assert.ok(!workspaceManifest.dependencies?.[packageName], `${packageName} remains a dependency`)
+    assert.ok(
+      !workspaceManifest.devDependencies?.[packageName],
+      `${packageName} remains a development dependency`,
+    )
+  }
+  assert.ok(!lockfile.includes(`${packageName}@`), `${packageName} remains in the lockfile`)
+}
+
+const trackedFiles = execFileSync('git', ['ls-files'], {
+  cwd: repositoryRoot,
+  encoding: 'utf8',
+})
+  .trim()
+  .split('\n')
+  .filter(Boolean)
+assert.deepEqual(
+  trackedFiles.filter((path) => /(^|\/)(?:node_modules|dist|out|\.next)(?:\/|$)/.test(path)),
+  [],
+  'Generated dependency, library, or documentation output must not be tracked',
+)
+assert.ok(!trackedFiles.some((path) => path.startsWith('docs/.island/')))
+assert.ok(!trackedFiles.includes('scripts/verify-island-style-parity.mjs'))
+
+const dependencyTrees = JSON.parse(
+  execFileSync(
+    'pnpm',
+    [
+      '--recursive',
+      'list',
+      'react',
+      'react-dom',
+      'tone',
+      'tailwindcss',
+      '--depth',
+      'Infinity',
+      '--json',
+    ],
+    { cwd: repositoryRoot, encoding: 'utf8' },
+  ),
+)
+const versions = new Map(
+  ['react', 'react-dom', 'tone', 'tailwindcss'].map((name) => [name, new Set()]),
+)
+const visitDependencies = (node) => {
+  for (const group of ['dependencies', 'devDependencies', 'optionalDependencies']) {
+    for (const [name, dependency] of Object.entries(node[group] ?? {})) {
+      if (versions.has(name) && dependency.version && !dependency.version.startsWith('link:')) {
+        versions.get(name).add(dependency.version)
+      }
+      visitDependencies(dependency)
+    }
+  }
+}
+for (const tree of dependencyTrees) visitDependencies(tree)
+assert.deepEqual([...versions.get('react')], [releaseMatrix.react.workspace])
+assert.deepEqual([...versions.get('react-dom')], [releaseMatrix.react.workspace])
+assert.deepEqual([...versions.get('tone')], [releaseMatrix.tone.tested])
+assert.deepEqual([...versions.get('tailwindcss')], [releaseMatrix.tailwind.workspace])
+
+const requiredReleaseNotes = [
+  '# Echo UI 1.1.0 release notes',
+  'Node.js 24',
+  'pnpm 10.22.0',
+  'React 18.3.1',
+  'React 19.2.8',
+  'Tailwind CSS 3.4.19',
+  'Tailwind CSS 4.3.3',
+  'Nextra 4.6.0',
+  'Tone.js 15.1.22',
+  'legacy documentation redirects',
+  '`main`/`module`/`types`/`style`',
+  'externalized',
+  'classic JSX runtime',
+  '`React` injection',
+  'pnpm verify:frozen',
+]
+for (const statement of requiredReleaseNotes) {
+  assert.ok(notes.includes(statement), `Release notes must document: ${statement}`)
+}
+
+console.log(`Echo UI ${releaseMatrix.echoUi} release contract is verified.`)

--- a/scripts/verify-tailwind-installation-docs.mjs
+++ b/scripts/verify-tailwind-installation-docs.mjs
@@ -1,6 +1,7 @@
 import assert from 'node:assert/strict'
 import { readFile } from 'node:fs/promises'
 import { resolve } from 'node:path'
+import { releaseMatrix } from './release-matrix.mjs'
 
 const repositoryRoot = resolve(import.meta.dirname, '..')
 const guides = [
@@ -17,8 +18,18 @@ const guides = [
 ]
 
 const requiredVersionRows = [
-  ['`1.1.x`', '`4.3.x`', '`3.2.x`', '`3.6.x`'],
-  ['`1.1.x`', '`3.4.x`', '`3.2.x`', '`3.6.x`'],
+  [
+    '`1.1.x`',
+    `\`${releaseMatrix.tailwind.tested.tailwind4.replace(/\.\d+$/, '.x')}\``,
+    '`3.2.x`',
+    '`3.6.x`',
+  ],
+  [
+    '`1.1.x`',
+    `\`${releaseMatrix.tailwind.tested.tailwind3.replace(/\.\d+$/, '.x')}\``,
+    '`3.2.x`',
+    '`3.6.x`',
+  ],
   ['`1.0.0`', '`3.3.5`', '`0.1.x`', '`2.x`'],
 ]
 
@@ -27,6 +38,12 @@ for (const guide of guides) {
 
   assert.match(source, /Tailwind CSS 4/, `${guide.locale} guide must recommend Tailwind 4`)
   assert.match(source, /Tailwind CSS 3/, `${guide.locale} guide must document Tailwind 3`)
+  for (const version of Object.values(releaseMatrix.tailwind.tested)) {
+    assert.ok(
+      source.includes(version),
+      `${guide.locale} guide must claim tested Tailwind ${version}`,
+    )
+  }
   assert.match(source, /@tailwindcss\/vite/, `${guide.locale} guide must configure the Vite plugin`)
   assert.match(
     source,

--- a/tests/package-entry.test.ts
+++ b/tests/package-entry.test.ts
@@ -111,7 +111,7 @@ describe('published package', () => {
           types: `./${expectedThemeEntries.tailwindThemeTypes}`,
         },
       },
-      files: ['dist'],
+      files: ['dist', 'RELEASE_NOTES.md'],
       sideEffects: ['**/*.css'],
     })
 

--- a/tests/release-verification.test.ts
+++ b/tests/release-verification.test.ts
@@ -1,0 +1,16 @@
+import { execFileSync } from 'node:child_process'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const repositoryRoot = resolve(import.meta.dirname, '..')
+
+describe('release verification', () => {
+  it('certifies the supported modernization matrix and release notes', () => {
+    const output = execFileSync(process.execPath, ['scripts/verify-release-contract.mjs'], {
+      cwd: repositoryRoot,
+      encoding: 'utf8',
+    })
+
+    expect(output).toMatch('Echo UI 1.1.0 release contract is verified.')
+  })
+})


### PR DESCRIPTION
## Summary

- add a frozen release contract covering the supported Node, pnpm, React, Tailwind, Nextra, and Tone versions
- audit the packed package exports, declarations, styles, side effects, bundle contents, and exact external dependency boundary
- verify isolated React 18/19 and Tailwind 3/4 consumers while documenting the production JSX compatibility bridge
- add release notes for the React, Tailwind, documentation, and Tone migrations

## Verification

- `pnpm verify:frozen`
- `pnpm lint`
- `pnpm exec vitest run`
- `pnpm test:package`
- `pnpm test:react-compat`
- `pnpm test:tailwind-compat`
- `pnpm test:tailwind-docs`

Closes #88