### PR TITLE
test(loop): isolate installer gh dependency

### DIFF
--- a/loops/issue-dev-loop/tests/install-trusted-control-plane.test.mjs
+++ b/loops/issue-dev-loop/tests/install-trusted-control-plane.test.mjs
@@ -62,10 +62,13 @@ test('installer atomically publishes a read-only trusted control plane', async (
   const installer = path.join(loopRoot, 'scripts', 'install-trusted-control-plane.mjs')
   const target = path.join(fixtureRoot, 'trusted-control-plane')
   const canonicalTarget = path.join(await realpath(fixtureRoot), 'trusted-control-plane')
+  const executableRoot = path.join(fixtureRoot, 'bin')
+  const fixtureGh = path.join(executableRoot, 'gh')
   await Promise.all([
     mkdir(path.dirname(installer), { recursive: true }),
     mkdir(path.join(loopRoot, 'triggers'), { recursive: true }),
     mkdir(path.join(repositoryRoot, 'loops', '_shared', 'owner-channel'), { recursive: true }),
+    mkdir(executableRoot),
   ])
   await Promise.all([
     cp(installerSource, installer),
@@ -75,6 +78,7 @@ test('installer atomically publishes a read-only trusted control plane', async (
       '{}\n',
       'utf8',
     ),
+    writeFile(fixtureGh, '#!/bin/sh\nexit 0\n', { encoding: 'utf8', mode: 0o755 }),
   ])
 
   await git(repositoryRoot, ['init', '--initial-branch=dev'])
@@ -94,6 +98,10 @@ test('installer atomically publishes a read-only trusted control plane', async (
 
   const { stdout } = await execFileAsync(process.execPath, [installer, '--target', target], {
     cwd: repositoryRoot,
+    env: {
+      ...process.env,
+      PATH: `${executableRoot}${path.delimiter}${process.env.PATH ?? ''}`,
+    },
   })
 
   const result = JSON.parse(stdout)
@@ -111,4 +119,5 @@ test('installer atomically publishes a read-only trusted control plane', async (
   )
   assert.equal(manifest.bundleRoot, canonicalTarget)
   assert.equal(manifest.sourceCommit, sourceCommit)
+  assert.equal(manifest.executables.gh, await realpath(fixtureGh))
 })


### PR DESCRIPTION
## Summary

- provide an executable fixture gh for the trusted-control-plane installer integration test
- prepend the fixture directory only for the installer subprocess
- assert the generated manifest binds the fixture executable

## Review finding

Resolves accepted finding RVW-1-1-1 from Traviinam review https://github.com/codeacme17/echo-ui/pull/109#pullrequestreview-4772945277. PR #109 was merged at head e794f6a before this repair was committed.

## Verification

- env PATH=/usr/bin:/bin /Users/leyoonafr/.nvm/versions/node/v24.5.0/bin/node --test loops/issue-dev-loop/tests/install-trusted-control-plane.test.mjs
- pnpm loop:issue-dev:test (87 tests passed)
- pnpm verify

## Risk

Low. This changes only the installer integration-test fixture and removes dependence on a host-installed gh binary.

Owner controls Ready, approval, and merge.