### PR TITLE
fix(loop): allow exact restore Git probes

### DIFF
--- a/loops/issue-dev-loop/scripts/lib/github-identity.mjs
+++ b/loops/issue-dev-loop/scripts/lib/github-identity.mjs
@@ -295,6 +295,21 @@ function authorizedPushBranches(authorization) {
 
 export function assertGitCommandPolicy(role, args, { authorization = null } = {}) {
   const subcommand = gitSubcommand(args)
+  const restoreCleanlinessProbe =
+    role === 'automation' &&
+    (sameArguments(args, ['ls-files', '-v', '-z']) ||
+      sameArguments(args, [
+        '-c',
+        'core.fileMode=true',
+        'diff',
+        '--quiet',
+        '--no-ext-diff',
+        '--no-textconv',
+        'HEAD',
+        '--',
+      ]))
+  if (restoreCleanlinessProbe) return
+
   if (subcommand.name === 'push') {
     if (role === 'reviewer') throw new Error('reviewer identity cannot run git push')
     const claimBranch = authorization?.issue?.branch

--- a/loops/issue-dev-loop/tests/github-identity-routing.test.mjs
+++ b/loops/issue-dev-loop/tests/github-identity-routing.test.mjs
@@ -32,7 +32,10 @@ import {
   canonicalFinalizationRecord,
   finalizationRecordDigest,
 } from '../scripts/lib/finalization-proof.mjs'
-import { resolveExecutable } from '../scripts/lib/github-identity.mjs'
+import {
+  assertGitCommandPolicy,
+  resolveExecutable,
+} from '../scripts/lib/github-identity.mjs'
 
 const execFileAsync = promisify(execFile)
 const testDirectory = path.dirname(fileURLToPath(import.meta.url))
@@ -2321,6 +2324,39 @@ test('authenticated remote Git accepts only exact origin and authorized ref shap
     const executed = JSON.parse(stdout)
     assert.match(executed.args.join(' '), /https:\/\/github\.com\/example\/repo\.git/)
     assert.doesNotMatch(executed.args.join(' '), /--upload-pack|attacker/)
+  }
+})
+
+test('automation allows only the exact restore cleanliness Git probes', () => {
+  for (const args of [
+    ['ls-files', '-v', '-z'],
+    [
+      '-c',
+      'core.fileMode=true',
+      'diff',
+      '--quiet',
+      '--no-ext-diff',
+      '--no-textconv',
+      'HEAD',
+      '--',
+    ],
+  ]) {
+    assert.doesNotThrow(() => assertGitCommandPolicy('automation', args))
+    assert.throws(
+      () => assertGitCommandPolicy('reviewer', args),
+      /outside the authenticated reviewer command tree/,
+    )
+  }
+  for (const args of [
+    ['ls-files', '-v'],
+    ['ls-files', '-v', '-z', '--others'],
+    ['-c', 'core.fileMode=false', 'diff', '--quiet', 'HEAD', '--'],
+    ['-c', 'core.fileMode=true', 'diff', 'HEAD', '--'],
+  ]) {
+    assert.throws(
+      () => assertGitCommandPolicy('automation', args),
+      /outside the authenticated automation command tree/,
+    )
   }
 })
 


### PR DESCRIPTION
## Summary

- allow the trusted automation descendant gate to run only the two exact read-only Git probes used by restore-checkpoint
- keep all broader ls-files and git -c shapes denied
- add allow/deny routing regressions

## Verification

- pnpm exec eslint loops/issue-dev-loop/scripts/lib/github-identity.mjs loops/issue-dev-loop/tests/github-identity-routing.test.mjs
- node --test loops/issue-dev-loop/tests/github-identity-routing.test.mjs (47/47)
- pnpm loop:issue-dev:test (105/105)
- loop validation: 67 files

## Context

This is an owner-reviewed control-plane bootstrap fix discovered while resuming #108. The merged restore cleanliness check invokes these probes through the authenticated descendant Git gate; without the exact allowlist entries, restore-checkpoint is blocked before restoring the durable checkpoint.

This PR must remain Draft. Only codeacme17 may mark it Ready, approve, or merge it.